### PR TITLE
Optimize ParallelFor loops

### DIFF
--- a/Source/TurboSequence_Lf/Private/TurboSequence_Demo_Lf.cpp
+++ b/Source/TurboSequence_Lf/Private/TurboSequence_Demo_Lf.cpp
@@ -311,290 +311,277 @@ void ATurboSequence_Demo_Lf::SolveGroup(int32 GroupIndex,
 	}
 	FCriticalSection CriticalSection;
 
-	int16 NumThreads = FTurboSequence_Helper_Lf::NumCPUThreads() - GET1_NUMBER;
-	int32 NumMeshesPerThread = FMath::CeilToInt(
-		static_cast<float>(NumMeshes) / static_cast<float>(NumThreads));
-	ParallelFor(NumThreads, [&](int32 ThreadsIndex)
+	ParallelFor(NumMeshes, [&](int32 Index)
 	{
-		const int32 MeshBaseIndex = ThreadsIndex * NumMeshesPerThread;
-		const int32 MeshBaseNum = MeshBaseIndex + NumMeshesPerThread;
+		const FTurboSequence_MinimalMeshData_Lf& MeshData =
+			ATurboSequence_Manager_Lf::GetMeshDataInUpdateGroupFromIndex_Concurrent(GroupIndex, Index);
 
-		for (int32 Index = MeshBaseIndex; Index < MeshBaseNum; ++Index)
+		if (!MeshData.IsMeshDataValid() || (MeshData.IsMeshDataValid() && !Meshes.Contains(MeshData)))
 		{
-			if (Index >= NumMeshes)
+			return;
+		}
+
+		FDemoMeshWrapper_Lf& Mesh = Meshes[MeshData];
+		//
+		// SolveMesh(Mesh, CriticalSection, CameraRotation, CameraLocation, SwitchingGroups, DeltaTime);
+
+		const FDemoAssetData_Lf* AssetCustomData = AssetDataRuntime[Mesh.AssetDataIndex];
+		const TObjectPtr<UTurboSequence_MeshAsset_Lf> MeshAsset =
+			ATurboSequence_Manager_Lf::GetMeshAsset_RawID_Concurrent(
+				Mesh.MeshData.RootMotionMeshID);
+
+		// Here we make a simple Distance Updating in seconds, if DeltaTimeAccumulator is accumulated
+		// higher than DistanceRatioSeconds we update the Mesh
+		// this is truly optional and only here for optimization
+		float CameraDistance = ATurboSequence_Manager_Lf::GetMeshClosestCameraDistance_Concurrent(
+			Mesh.MeshData);
+		float DistanceRatioSeconds = MeshAsset->bUseDistanceUpdating
+			                             ? CameraDistance / 250000 * MeshAsset->DistanceUpdatingRatio
+			                             : 0;
+
+		Mesh.DeltaTimeAccumulator += DeltaTime;
+		if (Mesh.DeltaTimeAccumulator > DistanceRatioSeconds)
+		{
+			if (AssetCustomData->bUseRootMotion)
 			{
-				break;
+				ATurboSequence_Manager_Lf::MoveMeshWithRootMotion_Concurrent(
+					Mesh.MeshData, Mesh.DeltaTimeAccumulator, true, false);
 			}
-
-			const FTurboSequence_MinimalMeshData_Lf& MeshData =
-				ATurboSequence_Manager_Lf::GetMeshDataInUpdateGroupFromIndex_Concurrent(GroupIndex, Index);
-
-			if (!MeshData.IsMeshDataValid() || (MeshData.IsMeshDataValid() && !Meshes.Contains(MeshData)))
+			else if (AssetCustomData->bUseProgrammableSpeed)
 			{
-				continue;
-			}
+				const TObjectPtr<UAnimSequence> AnimSequence =
+					ATurboSequence_Manager_Lf::GetHighestPriorityPlayingAnimation_Concurrent(Mesh.MeshData);
 
-			FDemoMeshWrapper_Lf& Mesh = Meshes[MeshData];
-			//
-			// SolveMesh(Mesh, CriticalSection, CameraRotation, CameraLocation, SwitchingGroups, DeltaTime);
-
-			const FDemoAssetData_Lf* AssetCustomData = AssetDataRuntime[Mesh.AssetDataIndex];
-			const TObjectPtr<UTurboSequence_MeshAsset_Lf> MeshAsset =
-				ATurboSequence_Manager_Lf::GetMeshAsset_RawID_Concurrent(
-					Mesh.MeshData.RootMotionMeshID);
-
-			// Here we make a simple Distance Updating in seconds, if DeltaTimeAccumulator is accumulated
-			// higher than DistanceRatioSeconds we update the Mesh
-			// this is truly optional and only here for optimization
-			float CameraDistance = ATurboSequence_Manager_Lf::GetMeshClosestCameraDistance_Concurrent(
-				Mesh.MeshData);
-			float DistanceRatioSeconds = MeshAsset->bUseDistanceUpdating
-				                             ? CameraDistance / 250000 * MeshAsset->DistanceUpdatingRatio
-				                             : 0;
-
-			Mesh.DeltaTimeAccumulator += DeltaTime;
-			if (Mesh.DeltaTimeAccumulator > DistanceRatioSeconds)
-			{
-				if (AssetCustomData->bUseRootMotion)
+				if (IsValid(MeshAsset->AnimationLibrary))
 				{
-					ATurboSequence_Manager_Lf::MoveMeshWithRootMotion_Concurrent(
-						Mesh.MeshData, Mesh.DeltaTimeAccumulator, true, false);
-				}
-				else if (AssetCustomData->bUseProgrammableSpeed)
-				{
-					const TObjectPtr<UAnimSequence> AnimSequence =
-						ATurboSequence_Manager_Lf::GetHighestPriorityPlayingAnimation_Concurrent(Mesh.MeshData);
-
-					if (IsValid(MeshAsset->AnimationLibrary))
+					FVector Speed = FVector::ZeroVector;
+					for (FAnimationLibraryItem_Lf& AnimationLibraryItem : MeshAsset->AnimationLibrary->Animations)
 					{
-						FVector Speed = FVector::ZeroVector;
-						for (FAnimationLibraryItem_Lf& AnimationLibraryItem : MeshAsset->AnimationLibrary->Animations)
+						if (AnimationLibraryItem.Animation == AnimSequence)
 						{
-							if (AnimationLibraryItem.Animation == AnimSequence)
-							{
-								Speed = AnimationLibraryItem.AnimationSeed_CM_Per_Second;
-								break;
-							}
+							Speed = AnimationLibraryItem.AnimationSeed_CM_Per_Second;
+							break;
 						}
-
-						FTransform MeshTransform = ATurboSequence_Manager_Lf::GetMeshWorldSpaceTransform_Concurrent(
-							Mesh.MeshData);
-
-						MeshTransform.SetLocation(
-							MeshTransform.GetLocation() + MeshTransform.GetRotation().RotateVector(Speed * DeltaTime));
-
-						ATurboSequence_Manager_Lf::SetMeshWorldSpaceTransform_Concurrent(Mesh.MeshData, MeshTransform);
 					}
-				}
-				if (bKeepHeightOnSpawnLevel)
-				{
+
 					FTransform MeshTransform = ATurboSequence_Manager_Lf::GetMeshWorldSpaceTransform_Concurrent(
 						Mesh.MeshData);
 
-					FVector Location = MeshTransform.GetLocation();
-					Location.Z = DemoComponentHeight;
-					MeshTransform.SetLocation(Location);
+					MeshTransform.SetLocation(
+						MeshTransform.GetLocation() + MeshTransform.GetRotation().RotateVector(Speed * DeltaTime));
 
 					ATurboSequence_Manager_Lf::SetMeshWorldSpaceTransform_Concurrent(Mesh.MeshData, MeshTransform);
 				}
+			}
+			if (bKeepHeightOnSpawnLevel)
+			{
+				FTransform MeshTransform = ATurboSequence_Manager_Lf::GetMeshWorldSpaceTransform_Concurrent(
+					Mesh.MeshData);
 
-				if (AssetCustomData->bUseRandomRotation)
+				FVector Location = MeshTransform.GetLocation();
+				Location.Z = DemoComponentHeight;
+				MeshTransform.SetLocation(Location);
+
+				ATurboSequence_Manager_Lf::SetMeshWorldSpaceTransform_Concurrent(Mesh.MeshData, MeshTransform);
+			}
+
+			if (AssetCustomData->bUseRandomRotation)
+			{
+				Mesh.RandomRotationTimer -= Mesh.DeltaTimeAccumulator;
+				if (Mesh.RandomRotationTimer < 0)
 				{
-					Mesh.RandomRotationTimer -= Mesh.DeltaTimeAccumulator;
-					if (Mesh.RandomRotationTimer < 0)
-					{
-						Mesh.RandomRotationTimer = FMath::RandRange(2.0f, 7.0f);
-						const float RandomYaw = FMath::RandRange(-180.0f, 180.0f);
+					Mesh.RandomRotationTimer = FMath::RandRange(2.0f, 7.0f);
+					const float RandomYaw = FMath::RandRange(-180.0f, 180.0f);
 
-						Mesh.RandomRotationYaw = RandomYaw;
-					}
-
-					FTransform MeshTransform = ATurboSequence_Manager_Lf::GetMeshWorldSpaceTransform_Concurrent(
-						Mesh.MeshData);
-					FRotator Rotation = MeshTransform.Rotator();
-
-					Rotation.Yaw = FRotator::NormalizeAxis(
-						FMath::Lerp(Rotation.Yaw, static_cast<double>(Mesh.RandomRotationYaw),
-						            static_cast<double>(Mesh.DeltaTimeAccumulator)));
-
-					//MeshTransform.SetRotation(Rotation.Quaternion());
-					ATurboSequence_Manager_Lf::SetMeshWorldSpaceLocationRotationScale_Concurrent(
-						Mesh.MeshData, MeshTransform.GetLocation(), Rotation.Quaternion(), FVector::OneVector);
+					Mesh.RandomRotationYaw = RandomYaw;
 				}
 
-				if (AssetCustomData->bUseRandomAnimation)
+				FTransform MeshTransform = ATurboSequence_Manager_Lf::GetMeshWorldSpaceTransform_Concurrent(
+					Mesh.MeshData);
+				FRotator Rotation = MeshTransform.Rotator();
+
+				Rotation.Yaw = FRotator::NormalizeAxis(
+					FMath::Lerp(Rotation.Yaw, static_cast<double>(Mesh.RandomRotationYaw),
+					            static_cast<double>(Mesh.DeltaTimeAccumulator)));
+
+				//MeshTransform.SetRotation(Rotation.Quaternion());
+				ATurboSequence_Manager_Lf::SetMeshWorldSpaceLocationRotationScale_Concurrent(
+					Mesh.MeshData, MeshTransform.GetLocation(), Rotation.Quaternion(), FVector::OneVector);
+			}
+
+			if (AssetCustomData->bUseRandomAnimation)
+			{
+				Mesh.RandomAnimationTimer -= Mesh.DeltaTimeAccumulator;
+				if (Mesh.RandomAnimationTimer < 0)
 				{
-					Mesh.RandomAnimationTimer -= Mesh.DeltaTimeAccumulator;
-					if (Mesh.RandomAnimationTimer < 0)
+					if (IsValid(MeshAsset->AnimationLibrary)) // TODO: Remove
 					{
-						if (IsValid(MeshAsset->AnimationLibrary)) // TODO: Remove
+						if (AssetCustomData->bUseBlendSpaces && CameraDistance < 15000)
 						{
-							if (AssetCustomData->bUseBlendSpaces && CameraDistance < 15000)
+							if (int32 NumBlendSpaces = MeshAsset->AnimationLibrary->BlendSpaces.Num())
 							{
-								if (int32 NumBlendSpaces = MeshAsset->AnimationLibrary->BlendSpaces.Num())
+								int32 RandomBlendSpace = FMath::RandRange(0, NumBlendSpaces - 1);
+								FTurboSequence_AnimPlaySettings_Lf PlaySettings =
+									FTurboSequence_AnimPlaySettings_Lf();
+
+								if (!Mesh.CurrentBlendSpace.IsAnimCollectionValid() || Mesh.CurrentBlendSpace.
+									RootMotionMesh.BlendSpace != MeshAsset->AnimationLibrary->BlendSpaces[
+										RandomBlendSpace])
 								{
-									int32 RandomBlendSpace = FMath::RandRange(0, NumBlendSpaces - 1);
-									FTurboSequence_AnimPlaySettings_Lf PlaySettings =
-										FTurboSequence_AnimPlaySettings_Lf();
-
-									if (!Mesh.CurrentBlendSpace.IsAnimCollectionValid() || Mesh.CurrentBlendSpace.
-										RootMotionMesh.BlendSpace != MeshAsset->AnimationLibrary->BlendSpaces[
-											RandomBlendSpace])
-									{
-										Mesh.CurrentBlendSpace = ATurboSequence_Manager_Lf::PlayBlendSpace_Concurrent(
-											Mesh.MeshData, MeshAsset->AnimationLibrary->BlendSpaces[RandomBlendSpace],
-											PlaySettings);
-									}
-
-									Mesh.RandomBlendSpacePosition = FVector3f(
-										FMath::RandRange(-200.0, 200.0), FMath::RandRange(-200.0, 200.0), 0);
-									if (FVector3f::Distance(Mesh.RandomBlendSpacePosition, FVector3f::ZeroVector) < 100)
-									{
-										Mesh.RandomBlendSpacePosition = FVector3f::ZeroVector;
-									}
-									else
-									{
-										Mesh.RandomBlendSpacePosition = Mesh.RandomBlendSpacePosition.GetUnsafeNormal() * 200;
-									}
-
-									ATurboSequence_Manager_Lf::TweakBlendSpace_Concurrent(
-										Mesh.CurrentBlendSpace, Mesh.RandomBlendSpacePosition);
+									Mesh.CurrentBlendSpace = ATurboSequence_Manager_Lf::PlayBlendSpace_Concurrent(
+										Mesh.MeshData, MeshAsset->AnimationLibrary->BlendSpaces[RandomBlendSpace],
+										PlaySettings);
 								}
-							}
-							else
-							{
-								if (int32 NumAnimations = MeshAsset->AnimationLibrary->Animations.Num())
+
+								Mesh.RandomBlendSpacePosition = FVector3f(
+									FMath::RandRange(-200.0, 200.0), FMath::RandRange(-200.0, 200.0), 0);
+								if (FVector3f::Distance(Mesh.RandomBlendSpacePosition, FVector3f::ZeroVector) < 100)
 								{
-									int32 RandomAnimation = FMath::RandRange(0, NumAnimations - 1);
+									Mesh.RandomBlendSpacePosition = FVector3f::ZeroVector;
+								}
+								else
+								{
+									Mesh.RandomBlendSpacePosition = Mesh.RandomBlendSpacePosition.GetUnsafeNormal() *
+										200;
+								}
+
+								ATurboSequence_Manager_Lf::TweakBlendSpace_Concurrent(
+									Mesh.CurrentBlendSpace, Mesh.RandomBlendSpacePosition);
+							}
+						}
+						else
+						{
+							if (int32 NumAnimations = MeshAsset->AnimationLibrary->Animations.Num())
+							{
+								int32 RandomAnimation = FMath::RandRange(0, NumAnimations - 1);
+								if (NumAnimations > 1)
+								{
+									while (ATurboSequence_Manager_Lf::GetHighestPriorityPlayingAnimation_Concurrent(
+											Mesh.MeshData) == MeshAsset->AnimationLibrary->Animations[
+											RandomAnimation].
+										Animation)
+									{
+										RandomAnimation = FMath::RandRange(0, NumAnimations - 1);
+									}
+								}
+								FTurboSequence_AnimPlaySettings_Lf PlaySettings =
+									FTurboSequence_AnimPlaySettings_Lf();
+								Mesh.CurrentAnimation_0 = ATurboSequence_Manager_Lf::PlayAnimation_Concurrent(
+									Mesh.MeshData,
+									MeshAsset->AnimationLibrary->Animations[RandomAnimation].Animation,
+									PlaySettings);
+
+								if (AssetCustomData->bUseLayer)
+								{
+									int32 RandomAnimation2 = FMath::RandRange(0, NumAnimations - 1);
 									if (NumAnimations > 1)
 									{
-										while (ATurboSequence_Manager_Lf::GetHighestPriorityPlayingAnimation_Concurrent(
+										while (
+											ATurboSequence_Manager_Lf::GetHighestPriorityPlayingAnimation_Concurrent(
 												Mesh.MeshData) == MeshAsset->AnimationLibrary->Animations[
-												RandomAnimation].
-											Animation)
+												RandomAnimation2].Animation)
 										{
-											RandomAnimation = FMath::RandRange(0, NumAnimations - 1);
+											RandomAnimation2 = FMath::RandRange(0, NumAnimations - 1);
 										}
 									}
-									FTurboSequence_AnimPlaySettings_Lf PlaySettings =
-										FTurboSequence_AnimPlaySettings_Lf();
-									Mesh.CurrentAnimation_0 = ATurboSequence_Manager_Lf::PlayAnimation_Concurrent(
+									PlaySettings.AnimationPlayTimeInSeconds = FMath::RandRange(0.0f, 0.5f);
+									PlaySettings.BoneLayerMasks = AssetCustomData->BoneLayers;
+									//PlaySettings.Animation = MeshAsset->AnimationLibrary->Animations[RandomAnimation2];
+									Mesh.CurrentAnimation_1 = ATurboSequence_Manager_Lf::PlayAnimation_Concurrent(
 										Mesh.MeshData,
-										MeshAsset->AnimationLibrary->Animations[RandomAnimation].Animation,
+										MeshAsset->AnimationLibrary->Animations[RandomAnimation2].Animation,
 										PlaySettings);
-
-									if (AssetCustomData->bUseLayer)
-									{
-										int32 RandomAnimation2 = FMath::RandRange(0, NumAnimations - 1);
-										if (NumAnimations > 1)
-										{
-											while (
-												ATurboSequence_Manager_Lf::GetHighestPriorityPlayingAnimation_Concurrent(
-													Mesh.MeshData) == MeshAsset->AnimationLibrary->Animations[
-													RandomAnimation2].Animation)
-											{
-												RandomAnimation2 = FMath::RandRange(0, NumAnimations - 1);
-											}
-										}
-										PlaySettings.AnimationPlayTimeInSeconds = FMath::RandRange(0.0f, 0.5f);
-										PlaySettings.BoneLayerMasks = AssetCustomData->BoneLayers;
-										//PlaySettings.Animation = MeshAsset->AnimationLibrary->Animations[RandomAnimation2];
-										Mesh.CurrentAnimation_1 = ATurboSequence_Manager_Lf::PlayAnimation_Concurrent(
-											Mesh.MeshData,
-											MeshAsset->AnimationLibrary->Animations[RandomAnimation2].Animation,
-											PlaySettings);
-									}
 								}
 							}
 						}
-
-						Mesh.RandomAnimationTimer = FMath::RandRange(2.0f, 7.0f);
-						Mesh.RandomAnimationData_0 = FMath::RandRange(0.9f, 1.75f);
-						Mesh.RandomAnimationData_1 = FMath::RandRange(0.9f, 1.75f);
 					}
 
-					if (AssetCustomData->bUseCustomData)
-					{
-						Mesh.CustomDataTimer -= Mesh.DeltaTimeAccumulator;
-						if (Mesh.CustomDataTimer < 0)
-						{
-							Mesh.CustomDataTimer = FMath::RandRange(2.0f, 5.0f);
-
-							const FLinearColor& RandomColor = FLinearColor::MakeRandomColor();
-
-							ATurboSequence_Manager_Lf::SetCustomDataToInstance_Concurrent(
-								Mesh.MeshData, 4, RandomColor.R);
-							ATurboSequence_Manager_Lf::SetCustomDataToInstance_Concurrent(
-								Mesh.MeshData, 5, RandomColor.G);
-							ATurboSequence_Manager_Lf::SetCustomDataToInstance_Concurrent(
-								Mesh.MeshData, 6, RandomColor.B);
-						}
-					}
+					Mesh.RandomAnimationTimer = FMath::RandRange(2.0f, 7.0f);
+					Mesh.RandomAnimationData_0 = FMath::RandRange(0.9f, 1.75f);
+					Mesh.RandomAnimationData_1 = FMath::RandRange(0.9f, 1.75f);
 				}
 
-
-				// IK is expensive on the CPU, we only do IK for 100 Meters Radius around the camera
-				// and only if the mesh is visible by the Camera Frustum
-				if (AssetCustomData->bUseIK && CameraDistance < 10000 &&
-					ATurboSequence_Manager_Lf::GetIsMeshVisibleInCameraFrustum_Concurrent(Mesh.MeshData, false))
+				if (AssetCustomData->bUseCustomData)
 				{
-					const FTransform& OffsetTransform = AssetCustomData->SpawnOffsetTransform;
-
-					const FTransform& MeshTransform =
-						ATurboSequence_Manager_Lf::GetMeshWorldSpaceTransform_Concurrent(Mesh.MeshData) *
-						OffsetTransform.Inverse();
-
-					float Dot = FVector::DotProduct(CameraRotation.Vector(),
-					                                MeshTransform.GetRotation().Vector());
-					bool bIsInView = Dot < 0;
-
-					Mesh.IKWeight = FTurboSequence_Helper_Lf::Clamp01(FMath::Lerp(
-						Mesh.IKWeight, static_cast<float>(bIsInView),
-						bIsInView ? 2.0f * Mesh.DeltaTimeAccumulator : 5.0f * Mesh.DeltaTimeAccumulator));
-
-
-					// This Look At IK need to be done backwards like so many IKs because,
-					// If I move first the head and add the movement from spine I end up with
-					// a location and rotation offset on head
-					// Another thing is we need to add DeltaTime into the IK Because GetIKTransform
-					// is sometimes updating the Animation to stay up to date
-					SolveLookAtIKBone(Mesh.MeshData, AssetCustomData->Spine1Bone, CameraLocation, Mesh.IKWeight,
-					                  AssetCustomData->Spine1IKStiffness, DeltaTime,
-					                  OffsetTransform);
-					SolveLookAtIKBone(Mesh.MeshData, AssetCustomData->Spine2Bone, CameraLocation, Mesh.IKWeight,
-					                  AssetCustomData->Spine2IKStiffness, DeltaTime,
-					                  OffsetTransform);
-					SolveLookAtIKBone(Mesh.MeshData, AssetCustomData->NeckBone, CameraLocation, Mesh.IKWeight,
-					                  AssetCustomData->NeckIKStiffness, DeltaTime,
-					                  OffsetTransform);
-					SolveLookAtIKBone(Mesh.MeshData, AssetCustomData->HeadBone, CameraLocation, Mesh.IKWeight,
-					                  AssetCustomData->HeadIKStiffness, DeltaTime,
-					                  OffsetTransform);
-				}
-
-				if (CameraDistance < RadiusOfHighQualitySolving)
-				{
-					if (Mesh.CurrentUpdateGroupIndex == Mesh.DefaultUpdateGroupIndex)
+					Mesh.CustomDataTimer -= Mesh.DeltaTimeAccumulator;
+					if (Mesh.CustomDataTimer < 0)
 					{
-						CriticalSection.Lock();
-						SwitchingGroups.Add(Mesh.MeshData, true);
-						CriticalSection.Unlock();
+						Mesh.CustomDataTimer = FMath::RandRange(2.0f, 5.0f);
+
+						const FLinearColor& RandomColor = FLinearColor::MakeRandomColor();
+
+						ATurboSequence_Manager_Lf::SetCustomDataToInstance_Concurrent(
+							Mesh.MeshData, 4, RandomColor.R);
+						ATurboSequence_Manager_Lf::SetCustomDataToInstance_Concurrent(
+							Mesh.MeshData, 5, RandomColor.G);
+						ATurboSequence_Manager_Lf::SetCustomDataToInstance_Concurrent(
+							Mesh.MeshData, 6, RandomColor.B);
 					}
 				}
-				else
-				{
-					if (Mesh.CurrentUpdateGroupIndex == QualityGroupIndex)
-					{
-						CriticalSection.Lock();
-						SwitchingGroups.Add(Mesh.MeshData, false);
-						CriticalSection.Unlock();
-					}
-				}
-
-				Mesh.DeltaTimeAccumulator = 0;
 			}
+
+
+			// IK is expensive on the CPU, we only do IK for 100 Meters Radius around the camera
+			// and only if the mesh is visible by the Camera Frustum
+			if (AssetCustomData->bUseIK && CameraDistance < 10000 &&
+				ATurboSequence_Manager_Lf::GetIsMeshVisibleInCameraFrustum_Concurrent(Mesh.MeshData, false))
+			{
+				const FTransform& OffsetTransform = AssetCustomData->SpawnOffsetTransform;
+
+				const FTransform& MeshTransform =
+					ATurboSequence_Manager_Lf::GetMeshWorldSpaceTransform_Concurrent(Mesh.MeshData) *
+					OffsetTransform.Inverse();
+
+				float Dot = FVector::DotProduct(CameraRotation.Vector(),
+				                                MeshTransform.GetRotation().Vector());
+				bool bIsInView = Dot < 0;
+
+				Mesh.IKWeight = FTurboSequence_Helper_Lf::Clamp01(FMath::Lerp(
+					Mesh.IKWeight, static_cast<float>(bIsInView),
+					bIsInView ? 2.0f * Mesh.DeltaTimeAccumulator : 5.0f * Mesh.DeltaTimeAccumulator));
+
+
+				// This Look At IK need to be done backwards like so many IKs because,
+				// If I move first the head and add the movement from spine I end up with
+				// a location and rotation offset on head
+				// Another thing is we need to add DeltaTime into the IK Because GetIKTransform
+				// is sometimes updating the Animation to stay up to date
+				SolveLookAtIKBone(Mesh.MeshData, AssetCustomData->Spine1Bone, CameraLocation, Mesh.IKWeight,
+				                  AssetCustomData->Spine1IKStiffness, DeltaTime,
+				                  OffsetTransform);
+				SolveLookAtIKBone(Mesh.MeshData, AssetCustomData->Spine2Bone, CameraLocation, Mesh.IKWeight,
+				                  AssetCustomData->Spine2IKStiffness, DeltaTime,
+				                  OffsetTransform);
+				SolveLookAtIKBone(Mesh.MeshData, AssetCustomData->NeckBone, CameraLocation, Mesh.IKWeight,
+				                  AssetCustomData->NeckIKStiffness, DeltaTime,
+				                  OffsetTransform);
+				SolveLookAtIKBone(Mesh.MeshData, AssetCustomData->HeadBone, CameraLocation, Mesh.IKWeight,
+				                  AssetCustomData->HeadIKStiffness, DeltaTime,
+				                  OffsetTransform);
+			}
+
+			if (CameraDistance < RadiusOfHighQualitySolving)
+			{
+				if (Mesh.CurrentUpdateGroupIndex == Mesh.DefaultUpdateGroupIndex)
+				{
+					CriticalSection.Lock();
+					SwitchingGroups.Add(Mesh.MeshData, true);
+					CriticalSection.Unlock();
+				}
+			}
+			else
+			{
+				if (Mesh.CurrentUpdateGroupIndex == QualityGroupIndex)
+				{
+					CriticalSection.Lock();
+					SwitchingGroups.Add(Mesh.MeshData, false);
+					CriticalSection.Unlock();
+				}
+			}
+
+			Mesh.DeltaTimeAccumulator = 0;
 		}
-	}, EParallelForFlags::BackgroundPriority);
+	});
 }
 
 void ATurboSequence_Demo_Lf::GetRandomMeshSpawnData(FTurboSequence_MeshSpawnData_Lf& Data,
@@ -723,24 +710,10 @@ void ATurboSequence_Demo_Lf::SolveBlueprintDemoMeshesInCpp(const TArray<FTurboSe
 
 	if (bMultiThreaded)
 	{
-		int16 NumThreads = FTurboSequence_Helper_Lf::NumCPUThreads() - GET1_NUMBER;
-		int32 NumMeshesPerThread_Background = FMath::CeilToInt(
-			static_cast<float>(NumMeshes) / static_cast<float>(NumThreads));
-		ParallelFor(NumThreads, [&](int32 ThreadsIndex)
+		ParallelFor(NumMeshes, [&](int32 Index)
 		{
-			const int32 MeshBaseIndex = ThreadsIndex * NumMeshesPerThread_Background;
-			const int32 MeshBaseNum = MeshBaseIndex + NumMeshesPerThread_Background;
-
-			for (int32 Index = MeshBaseIndex; Index < MeshBaseNum; ++Index)
-			{
-				if (Index >= NumMeshes)
-				{
-					break;
-				}
-
-				RunnerFunction(MeshData[Index], Index);
-			}
-		}, EParallelForFlags::BackgroundPriority);
+			RunnerFunction(MeshData[Index], Index);
+		});
 	}
 	else
 	{

--- a/Source/TurboSequence_Lf/Private/TurboSequence_Manager_Lf.cpp
+++ b/Source/TurboSequence_Lf/Private/TurboSequence_Manager_Lf.cpp
@@ -288,6 +288,7 @@ FTurboSequence_MinimalMeshData_Lf ATurboSequence_Manager_Lf::AddSkinnedMeshInsta
 	const FTurboSequence_MeshSpawnData_Lf FromSpawnData, const FTransform SpawnTransform,
 	UWorld* InWorld)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(ATurboSequence_Manager_Lf::AddSkinnedMeshInstance_GameThread);
 	if (!IsValid(FromSpawnData.RootMotionMesh.Mesh))
 	{
 		UE_LOG(LogTurboSequence_Lf, Warning,
@@ -335,6 +336,7 @@ FTurboSequence_MinimalMeshData_Lf ATurboSequence_Manager_Lf::AddSkinnedMeshInsta
 bool ATurboSequence_Manager_Lf::RemoveSkinnedMeshInstance_GameThread(const FTurboSequence_MinimalMeshData_Lf& MeshData,
                                                                      UWorld* InWorld)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(ATurboSequence_Manager_Lf::RemoveSkinnedMeshInstance_GameThread);
 	bool bSuccess = false;
 
 	if (RemoveSkinnedMeshInstance_GameThread(MeshData.RootMotionMeshID, InWorld))
@@ -370,6 +372,7 @@ int32 ATurboSequence_Manager_Lf::AddSkinnedMeshInstance_GameThread(
 	const TObjectPtr<UTurboSequence_FootprintAsset_Lf>& FootprintAsset,
 	const int32 OverrideMeshID)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(ATurboSequence_Manager_Lf::AddSkinnedMeshInstance_GameThread);
 	SCOPE_CYCLE_COUNTER(Add_TurboSequenceMeshInstances_Lf);
 	{
 		if (!IsValid(FromAsset->GlobalData))
@@ -497,7 +500,8 @@ int32 ATurboSequence_Manager_Lf::AddSkinnedMeshInstance_GameThread(
 		}
 
 		// Now it's time to add the actual instance
-		FSkinnedMeshRuntime_Lf Runtime = FSkinnedMeshRuntime_Lf(GlobalLibrary.RuntimeSkinnedMeshes, GlobalLibrary.BlackListedMeshIDs, FromAsset,
+		FSkinnedMeshRuntime_Lf Runtime = FSkinnedMeshRuntime_Lf(GlobalLibrary.RuntimeSkinnedMeshes,
+		                                                        GlobalLibrary.BlackListedMeshIDs, FromAsset,
 		                                                        OverrideMeshID);
 		FSkinnedMeshRuntime_RenderThread_Lf Runtime_RenderThread = FSkinnedMeshRuntime_RenderThread_Lf(
 			Runtime.GetMeshID(), FromAsset);
@@ -596,6 +600,7 @@ int32 ATurboSequence_Manager_Lf::AddSkinnedMeshInstance_GameThread(
 bool ATurboSequence_Manager_Lf::RemoveSkinnedMeshInstance_GameThread(int32 MeshID,
                                                                      const TObjectPtr<UWorld> InWorld)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(ATurboSequence_Manager_Lf::RemoveSkinnedMeshInstance_GameThread);
 	if (!IsValid(InWorld))
 	{
 		return false;
@@ -732,6 +737,7 @@ bool ATurboSequence_Manager_Lf::RemoveSkinnedMeshInstance_GameThread(int32 MeshI
 void ATurboSequence_Manager_Lf::SolveMeshes_GameThread(float DeltaTime, UWorld* InWorld,
                                                        FTurboSequence_UpdateContext_Lf UpdateContext)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(ATurboSequence_Manager_Lf::SolveMeshes_GameThread);
 	SCOPE_CYCLE_COUNTER(STAT_Solve_TurboSequenceMeshes_Lf);
 	{
 		// When we are actually have any data, otherwise there is nothing to compute and we can return
@@ -769,194 +775,180 @@ void ATurboSequence_Manager_Lf::SolveMeshes_GameThread(float DeltaTime, UWorld* 
 		bool bMeshIsVisible = false;
 		//TArray<FInstanceQueue_Lf> QueuedMeshes;
 		const int32 NumMeshes = GlobalLibrary.UpdateGroups[UpdateContext.GroupIndex].RawIDs.Num();
-		int16 NumThreads = FTurboSequence_Helper_Lf::NumCPUThreads() - GET1_NUMBER;
-		int32 NumMeshesPerThread = FMath::CeilToInt(
-			static_cast<float>(NumMeshes) / static_cast<float>(NumThreads));
-		ParallelFor(NumThreads, [&](int32 ThreadsIndex)
+		ParallelFor(NumMeshes, [&](int32 Index)
 		{
-			const int32 MeshBaseIndex = ThreadsIndex * NumMeshesPerThread;
-			const int32 MeshBaseNum = MeshBaseIndex + NumMeshesPerThread;
-
-			for (int32 Index = MeshBaseIndex; Index < MeshBaseNum; ++Index)
+			if (!GlobalLibrary.UpdateGroups[
+				UpdateContext.GroupIndex].RawIDs.IsValidIndex(Index))
 			{
-				if (Index >= NumMeshes)
+				UE_LOG(LogTemp, Warning, TEXT("Index"))
+				return;
+			}
+
+			const int32 ID = GlobalLibrary.UpdateGroups[
+				UpdateContext.GroupIndex].RawIDs[Index];
+
+			if (!GlobalLibrary.RuntimeSkinnedMeshes.Contains(ID))
+			{
+				UE_LOG(LogTemp, Warning, TEXT("ID"))
+				return;
+			}
+			FSkinnedMeshRuntime_Lf& Runtime = GlobalLibrary.RuntimeSkinnedMeshes[ID];
+
+			FSkinnedMeshReference_Lf& Reference = GlobalLibrary.PerReferenceData[Runtime.DataAsset];
+			if (!IsValid(Instance) || !IsValid(Reference.FirstValidMeshLevelOfDetail))
+			{
+				if (!IsValid(Reference.FirstValidMeshLevelOfDetail))
 				{
-					break;
-				}
-
-				if (!GlobalLibrary.UpdateGroups[
-					UpdateContext.GroupIndex].RawIDs.IsValidIndex(Index))
-				{
-					UE_LOG(LogTemp, Warning, TEXT("Index"))
-					continue;
-				}
-
-				const int32 ID = GlobalLibrary.UpdateGroups[
-					UpdateContext.GroupIndex].RawIDs[Index];
-
-				if (!GlobalLibrary.RuntimeSkinnedMeshes.Contains(ID))
-				{
-					UE_LOG(LogTemp, Warning, TEXT("ID"))
-					continue;
-				}
-				FSkinnedMeshRuntime_Lf& Runtime = GlobalLibrary.RuntimeSkinnedMeshes[ID];
-
-				FSkinnedMeshReference_Lf& Reference = GlobalLibrary.PerReferenceData[Runtime.DataAsset];
-				if (!IsValid(Instance) || !IsValid(Reference.FirstValidMeshLevelOfDetail))
-				{
-					if (!IsValid(Reference.FirstValidMeshLevelOfDetail))
-					{
-						continue;
-					}
-
-					bMeshesSolvingAtTheMoment = false;
 					return;
 				}
 
-				if (IsValid(Runtime.FootprintAsset))
+				bMeshesSolvingAtTheMoment = false;
+				return;
+			}
+
+			if (IsValid(Runtime.FootprintAsset))
+			{
+				Runtime.FootprintAsset->OnMeshPreSolveAnimationMeta_Concurrent(Runtime.GetMeshID(), ThreadContext);
+			}
+
+
+			// Need to get always updated
+			FTurboSequence_Utility_Lf::SolveAnimations(Runtime,
+			                                           GlobalLibrary,
+			                                           GlobalLibrary_RenderThread,
+			                                           Reference,
+			                                           DeltaTime,
+			                                           CurrentFrameCount,
+			                                           ThreadContext);
+
+			// Update Visibility first because the LodElement.InstanceMap is maybe not correct if the LOD change
+			// and for the initial check we only need the LOD index
+			const bool bIsVisiblePrevious = FTurboSequence_Utility_Lf::GetIsMeshVisible(Runtime, Reference);
+			const int16 PreviousLodIndex = Runtime.LodIndex;
+			FTurboSequence_Utility_Lf::IsMeshVisible(Runtime, Reference, GlobalLibrary.CameraViews);
+
+			FTurboSequence_Utility_Lf::UpdateCullingAndLevelOfDetail(
+				Runtime, Reference, GlobalLibrary.CameraViews, ThreadContext, GlobalLibrary);
+			FSkinnedMeshReferenceLodElement_Lf& LodElement = Reference.LevelOfDetails[Runtime.LodIndex];
+
+			FTurboSequence_Utility_Lf::UpdateDistanceUpdating(Runtime, DeltaTime);
+
+			if (IsValid(Runtime.FootprintAsset))
+			{
+				Runtime.bIsVisible = !LodElement.bIsFrustumCullingEnabled || Runtime.bIsVisible;
+				Runtime.EIsVisibleOverride = ETurboSequence_IsVisibleOverride_Lf::Default;
+
+				Runtime.FootprintAsset->OnSetMeshIsVisible_Concurrent(
+					Runtime.EIsVisibleOverride, Runtime.bIsVisible, Runtime.GetMeshID(),
+					ThreadContext);
+
+				Runtime.bIsVisible = FTurboSequence_Utility_Lf::GetIsMeshVisible(Runtime, Reference);
+
+				FTurboSequence_Utility_Lf::UpdateRenderInstanceLod_Concurrent(
+					Reference, Runtime, LodElement, Runtime.bIsVisible && LodElement.bIsRenderStateValid);
+
+				Runtime.EIsAnimatedOverride = ETurboSequence_IsAnimatedOverride_Lf::Default;
+				Runtime.FootprintAsset->OnSetMeshIsAnimated_Concurrent(
+					Runtime.EIsAnimatedOverride, FTurboSequence_Utility_Lf::GetIsMeshAnimated(Runtime, Reference),
+					Runtime.GetMeshID(),
+					ThreadContext);
+				if (FTurboSequence_Utility_Lf::GetIsMeshAnimated(Runtime, Reference))
 				{
-					Runtime.FootprintAsset->OnMeshPreSolveAnimationMeta_Concurrent(Runtime.GetMeshID(), ThreadContext);
+					Runtime.bForceVisibilityUpdatingThisFrame = true;
 				}
+			}
+			else
+			{
+				Runtime.EIsVisibleOverride = ETurboSequence_IsVisibleOverride_Lf::Default;
+				Runtime.EIsAnimatedOverride = ETurboSequence_IsAnimatedOverride_Lf::Default;
 
-
-				// Need to get always updated
-				FTurboSequence_Utility_Lf::SolveAnimations(Runtime,
-				                                           GlobalLibrary,
-				                                           GlobalLibrary_RenderThread,
-				                                           Reference,
-				                                           DeltaTime,
-				                                           CurrentFrameCount,
-				                                           ThreadContext);
-
-				// Update Visibility first because the LodElement.InstanceMap is maybe not correct if the LOD change
-				// and for the initial check we only need the LOD index
-				const bool bIsVisiblePrevious = FTurboSequence_Utility_Lf::GetIsMeshVisible(Runtime, Reference);
-				const int16 PreviousLodIndex = Runtime.LodIndex;
-				FTurboSequence_Utility_Lf::IsMeshVisible(Runtime, Reference, GlobalLibrary.CameraViews);
-
-				FTurboSequence_Utility_Lf::UpdateCullingAndLevelOfDetail(
-					Runtime, Reference, GlobalLibrary.CameraViews, ThreadContext, GlobalLibrary);
-				FSkinnedMeshReferenceLodElement_Lf& LodElement = Reference.LevelOfDetails[Runtime.LodIndex];
-
-				FTurboSequence_Utility_Lf::UpdateDistanceUpdating(Runtime, DeltaTime);
-
-				if (IsValid(Runtime.FootprintAsset))
+				if (!LodElement.bIsFrustumCullingEnabled)
 				{
-					Runtime.bIsVisible = !LodElement.bIsFrustumCullingEnabled || Runtime.bIsVisible;
-					Runtime.EIsVisibleOverride = ETurboSequence_IsVisibleOverride_Lf::Default;
-
-					Runtime.FootprintAsset->OnSetMeshIsVisible_Concurrent(
-						Runtime.EIsVisibleOverride, Runtime.bIsVisible, Runtime.GetMeshID(),
-						ThreadContext);
-
-					Runtime.bIsVisible = FTurboSequence_Utility_Lf::GetIsMeshVisible(Runtime, Reference);
+					Runtime.bIsVisible = true;
 
 					FTurboSequence_Utility_Lf::UpdateRenderInstanceLod_Concurrent(
 						Reference, Runtime, LodElement, Runtime.bIsVisible && LodElement.bIsRenderStateValid);
-
-					Runtime.EIsAnimatedOverride = ETurboSequence_IsAnimatedOverride_Lf::Default;
-					Runtime.FootprintAsset->OnSetMeshIsAnimated_Concurrent(
-						Runtime.EIsAnimatedOverride, FTurboSequence_Utility_Lf::GetIsMeshAnimated(Runtime, Reference),
-						Runtime.GetMeshID(),
-						ThreadContext);
-					if (FTurboSequence_Utility_Lf::GetIsMeshAnimated(Runtime, Reference))
-					{
-						Runtime.bForceVisibilityUpdatingThisFrame = true;
-					}
 				}
-				else
-				{
-					Runtime.EIsVisibleOverride = ETurboSequence_IsVisibleOverride_Lf::Default;
-					Runtime.EIsAnimatedOverride = ETurboSequence_IsAnimatedOverride_Lf::Default;
-
-					if (!LodElement.bIsFrustumCullingEnabled)
-					{
-						Runtime.bIsVisible = true;
-
-						FTurboSequence_Utility_Lf::UpdateRenderInstanceLod_Concurrent(
-							Reference, Runtime, LodElement, Runtime.bIsVisible && LodElement.bIsRenderStateValid);
-					}
-				}
-
-				if (IsValid(Runtime.FootprintAsset))
-				{
-					if (bIsVisiblePrevious != FTurboSequence_Utility_Lf::GetIsMeshVisible(Runtime, Reference))
-					{
-						Runtime.FootprintAsset->OnGetMeshVisibilityChanged_Concurrent(
-							FTurboSequence_Utility_Lf::GetIsMeshVisible(Runtime, Reference), Runtime.GetMeshID(),
-							ThreadContext);
-					}
-					if (PreviousLodIndex != Runtime.LodIndex)
-					{
-						Runtime.FootprintAsset->OnGetMeshLodChanged_Concurrent(
-							PreviousLodIndex, Runtime.LodIndex, Runtime.GetMeshID(), ThreadContext);
-					}
-				}
-
-				// Need to be at last because bIsVisible is updating later
-				if (LodElement.bIsRenderStateValid)
-				{
-					FTurboSequence_Utility_Lf::SetCustomDataForInstance(
-						Reference, GlobalLibrary.MeshIDToGlobalIndex[Runtime.GetMeshID()], LodElement.SkinWeightOffset,
-						Runtime, GlobalLibrary);
-				}
-
-				if (FTurboSequence_Utility_Lf::GetIsMeshVisible(Runtime, Reference) || Runtime.
-					bForceVisibilityUpdatingThisFrame)
-				{
-					FTurboSequence_Utility_Lf::UpdateInstanceTransform_Internal(
-						Reference, Runtime, GlobalLibrary.CameraViews);
-
-					FTurboSequence_Utility_Lf::UpdateRendererBounds(ThreadContext->CriticalSection, Reference, Runtime);
-
-					if ((FTurboSequence_Utility_Lf::GetIsMeshAnimated(Runtime, Reference) && Runtime.
-						bIsDistanceUpdatingThisFrame && LodElement.
-						bIsRenderStateValid) || (Runtime.bForceVisibilityUpdatingThisFrame && LodElement.
-						bIsRenderStateValid))
-					{
-						Runtime.bForceVisibilityUpdatingThisFrame = false;
-
-						ThreadContext->CriticalSection.Lock();
-						bMeshIsVisible = true;
-						ThreadContext->CriticalSection.Unlock();
-						if (IsValid(Runtime.FootprintAsset))
-						{
-							Runtime.FootprintAsset->OnMeshFinalRenderingUpdate_Concurrent(
-								Runtime.GetMeshID(), ThreadContext);
-						}
-
-						const uint8 MeshIdx = LodElement.GPUMeshIndex;
-						const int32 MeshID = Runtime.GetMeshID();
-						const TArray<FAnimationMetaData_RenderThread_Lf> Animations_RenderThread = Runtime.
-							AnimationMetaData_RenderThread;
-						TMap<uint16, FIKBoneData_Lf> IK_RenderThread;
-						if (Runtime.bIKDataInUse)
-						{
-							IK_RenderThread = Runtime.IKData;
-						}
-						const bool bUseIK = Runtime.bIKDataInUse;
-
-						ENQUEUE_RENDER_COMMAND(TurboSequence_UpdateRenderInstance_Lf)(
-							[&Library_RenderThread = GlobalLibrary_RenderThread, MeshID, MeshIdx, bUseIK,
-								Animations_RenderThread,
-								IK_RenderThread](FRHICommandListImmediate& RHICmdList)
-							{
-								FSkinnedMeshRuntime_RenderThread_Lf& Runtime_RenderThread = Library_RenderThread.
-									RuntimeSkinnedMeshes[MeshID];
-
-								Runtime_RenderThread.bIsVisible = true;
-								Runtime_RenderThread.CurrentGPUMeshIndex = MeshIdx;
-								Runtime_RenderThread.AnimationMetaData_RenderThread = Animations_RenderThread;
-								Runtime_RenderThread.bIKDataInUse = bUseIK;
-								Runtime_RenderThread.IKData = IK_RenderThread;
-							});
-					}
-				}
-
-				// Better to manage it ourselves for easier use....
-				FTurboSequence_Utility_Lf::ClearIKState(Runtime, ThreadContext->CriticalSection);
 			}
-		}, EParallelForFlags::BackgroundPriority);
+
+			if (IsValid(Runtime.FootprintAsset))
+			{
+				if (bIsVisiblePrevious != FTurboSequence_Utility_Lf::GetIsMeshVisible(Runtime, Reference))
+				{
+					Runtime.FootprintAsset->OnGetMeshVisibilityChanged_Concurrent(
+						FTurboSequence_Utility_Lf::GetIsMeshVisible(Runtime, Reference), Runtime.GetMeshID(),
+						ThreadContext);
+				}
+				if (PreviousLodIndex != Runtime.LodIndex)
+				{
+					Runtime.FootprintAsset->OnGetMeshLodChanged_Concurrent(
+						PreviousLodIndex, Runtime.LodIndex, Runtime.GetMeshID(), ThreadContext);
+				}
+			}
+
+			// Need to be at last because bIsVisible is updating later
+			if (LodElement.bIsRenderStateValid)
+			{
+				FTurboSequence_Utility_Lf::SetCustomDataForInstance(
+					Reference, GlobalLibrary.MeshIDToGlobalIndex[Runtime.GetMeshID()], LodElement.SkinWeightOffset,
+					Runtime, GlobalLibrary);
+			}
+
+			if (FTurboSequence_Utility_Lf::GetIsMeshVisible(Runtime, Reference) || Runtime.
+				bForceVisibilityUpdatingThisFrame)
+			{
+				FTurboSequence_Utility_Lf::UpdateInstanceTransform_Internal(
+					Reference, Runtime, GlobalLibrary.CameraViews);
+
+				FTurboSequence_Utility_Lf::UpdateRendererBounds(ThreadContext->CriticalSection, Reference, Runtime);
+
+				if ((FTurboSequence_Utility_Lf::GetIsMeshAnimated(Runtime, Reference) && Runtime.
+					bIsDistanceUpdatingThisFrame && LodElement.
+					bIsRenderStateValid) || (Runtime.bForceVisibilityUpdatingThisFrame && LodElement.
+					bIsRenderStateValid))
+				{
+					Runtime.bForceVisibilityUpdatingThisFrame = false;
+
+					ThreadContext->CriticalSection.Lock();
+					bMeshIsVisible = true;
+					ThreadContext->CriticalSection.Unlock();
+					if (IsValid(Runtime.FootprintAsset))
+					{
+						Runtime.FootprintAsset->OnMeshFinalRenderingUpdate_Concurrent(
+							Runtime.GetMeshID(), ThreadContext);
+					}
+
+					const uint8 MeshIdx = LodElement.GPUMeshIndex;
+					const int32 MeshID = Runtime.GetMeshID();
+					const TArray<FAnimationMetaData_RenderThread_Lf> Animations_RenderThread = Runtime.
+						AnimationMetaData_RenderThread;
+					TMap<uint16, FIKBoneData_Lf> IK_RenderThread;
+					if (Runtime.bIKDataInUse)
+					{
+						IK_RenderThread = Runtime.IKData;
+					}
+					const bool bUseIK = Runtime.bIKDataInUse;
+
+					ENQUEUE_RENDER_COMMAND(TurboSequence_UpdateRenderInstance_Lf)(
+						[&Library_RenderThread = GlobalLibrary_RenderThread, MeshID, MeshIdx, bUseIK,
+							Animations_RenderThread,
+							IK_RenderThread](FRHICommandListImmediate& RHICmdList)
+						{
+							FSkinnedMeshRuntime_RenderThread_Lf& Runtime_RenderThread = Library_RenderThread.
+								RuntimeSkinnedMeshes[MeshID];
+
+							Runtime_RenderThread.bIsVisible = true;
+							Runtime_RenderThread.CurrentGPUMeshIndex = MeshIdx;
+							Runtime_RenderThread.AnimationMetaData_RenderThread = Animations_RenderThread;
+							Runtime_RenderThread.bIKDataInUse = bUseIK;
+							Runtime_RenderThread.IKData = IK_RenderThread;
+						});
+				}
+			}
+
+			// Better to manage it ourselves for easier use....
+			FTurboSequence_Utility_Lf::ClearIKState(Runtime, ThreadContext->CriticalSection);
+		});
 
 
 		FTurboSequence_Utility_Lf::UpdateAnimationLayerMasks(ThreadContext->CriticalSection, GlobalLibrary,
@@ -1007,6 +999,7 @@ void ATurboSequence_Manager_Lf::SolveMeshes_GameThread(float DeltaTime, UWorld* 
 
 void ATurboSequence_Manager_Lf::SolveMeshes_RenderThread(FRHICommandListImmediate& RHICmdList)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(ATurboSequence_Manager_Lf::SolveMeshes_RenderThread);
 	if (!IsValid(Instance))
 	{
 		return;
@@ -1017,96 +1010,77 @@ void ATurboSequence_Manager_Lf::SolveMeshes_RenderThread(FRHICommandListImmediat
 		return;
 	}
 
-
 	FCriticalSection CriticalSection;
 	const int32 NumMeshes = GlobalLibrary_RenderThread.RuntimeSkinnedMeshesHashMap.Num();
-	int16 NumThreads = FTurboSequence_Helper_Lf::NumCPUThreads() - GET1_NUMBER;
-	int32 NumMeshesPerThread = FMath::CeilToInt(static_cast<float>(NumMeshes) / static_cast<float>(NumThreads));
 
 	FTurboSequence_Utility_Lf::ResizeBuffers(GlobalLibrary_RenderThread, NumMeshes);
 
-
-	ParallelFor(NumThreads, [&](int32 ThreadsIndex)
+	ParallelFor(NumMeshes, [&](int32 Index)
 	{
-		const int32 MeshBaseIndex = ThreadsIndex * NumMeshesPerThread;
-		const int32 MeshBaseNum = MeshBaseIndex + NumMeshesPerThread;
+		FSkinnedMeshRuntime_RenderThread_Lf& Runtime = GlobalLibrary_RenderThread.RuntimeSkinnedMeshes[
+			GlobalLibrary_RenderThread.RuntimeSkinnedMeshesHashMap[Index]];
 
-		for (int32 Index = MeshBaseIndex; Index < MeshBaseNum; ++Index)
+		const FSkinnedMeshReference_RenderThread_Lf& Reference = GlobalLibrary_RenderThread.PerReferenceData[Runtime.
+			DataAsset];
+
+		GlobalLibrary_RenderThread.BoneTransformParams.BoneSpaceAnimationIKIndex_RenderThread[Index] = INDEX_NONE;
+
+		if (Runtime.bIsVisible)
 		{
-			if (Index >= NumMeshes)
+			CriticalSection.Lock();
+			const int32 MeshIndex = GlobalLibrary_RenderThread.NumMeshesVisibleCurrentFrame;
+			if (!FTurboSequence_Utility_Lf::IsValidBufferIndex(GlobalLibrary_RenderThread, MeshIndex))
 			{
-				break;
-			}
-
-			FSkinnedMeshRuntime_RenderThread_Lf& Runtime = GlobalLibrary_RenderThread.RuntimeSkinnedMeshes[
-				GlobalLibrary_RenderThread.RuntimeSkinnedMeshesHashMap[Index]];
-
-			const FSkinnedMeshReference_RenderThread_Lf& Reference = GlobalLibrary_RenderThread.PerReferenceData[Runtime
-				.
-				DataAsset];
-
-			GlobalLibrary_RenderThread.BoneTransformParams.BoneSpaceAnimationIKIndex_RenderThread[Index] = INDEX_NONE;
-
-			if (Runtime.bIsVisible)
-			{
-				CriticalSection.Lock();
-				const int32 MeshIndex = GlobalLibrary_RenderThread.NumMeshesVisibleCurrentFrame;
-				if (!FTurboSequence_Utility_Lf::IsValidBufferIndex(GlobalLibrary_RenderThread, MeshIndex))
-				{
-					CriticalSection.Unlock();
-
-					UE_LOG(LogTemp, Warning, TEXT("Not Valid Buffer Index... -> Mesh Index %d | Data Asset -> %s"),
-					       MeshIndex,
-					       *Runtime.DataAsset.GetName())
-					Runtime.bIsVisible = false;
-					Runtime.bIKDataInUse = false;
-					return;
-				}
-				GlobalLibrary_RenderThread.NumMeshesVisibleCurrentFrame++;
 				CriticalSection.Unlock();
 
-				GlobalLibrary_RenderThread.BoneTransformParams.PerMeshCustomDataIndex_RenderThread[MeshIndex] =
-					GlobalLibrary_RenderThread.MeshIDToGlobalIndex[Runtime.GetMeshID()];
+				UE_LOG(LogTemp, Warning, TEXT("Not Valid Buffer Index... -> Mesh Index %d | Data Asset -> %s"),
+				       MeshIndex,
+				       *Runtime.DataAsset.GetName())
+				Runtime.bIsVisible = false;
+				Runtime.bIKDataInUse = false;
+				return;
+			}
+			GlobalLibrary_RenderThread.NumMeshesVisibleCurrentFrame++;
+			CriticalSection.Unlock();
+
+			GlobalLibrary_RenderThread.BoneTransformParams.PerMeshCustomDataIndex_RenderThread[MeshIndex] =
+				GlobalLibrary_RenderThread.MeshIDToGlobalIndex[Runtime.GetMeshID()];
+
+			CriticalSection.Lock();
+			GlobalLibrary_RenderThread.NumAnimationsCurrentFrame += Runtime.AnimationMetaData_RenderThread.Num();
+			CriticalSection.Unlock();
+
+			if (Runtime.bIKDataInUse)
+			{
+				uint32 IKDataIndex = GET0_NUMBER;
+				uint16 IKBoneNum = GET0_NUMBER;
+				for (const TTuple<uint16, uint16>& BoneIdx : Reference.FirstLodGPUBonesCollection)
+				{
+					if (Runtime.IKData.Contains(BoneIdx.Key) && Runtime.IKData[BoneIdx.Key].
+						bIsInUsingWriteDataThisFrame && BoneIdx.Value != INDEX_NONE)
+					{
+						IKBoneNum++;
+					}
+
+					IKDataIndex += GET3_NUMBER;
+				}
+
+				if (IKBoneNum)
+				{
+					GlobalLibrary_RenderThread.BoneTransformParams.BoneSpaceAnimationIKIndex_RenderThread[Index] =
+						IKBoneNum;
+				}
 
 				CriticalSection.Lock();
-				GlobalLibrary_RenderThread.NumAnimationsCurrentFrame += Runtime.AnimationMetaData_RenderThread.Num();
-
-
+				GlobalLibrary_RenderThread.NumIKPixelCurrentFrame += IKBoneNum;
 				CriticalSection.Unlock();
-
-
-				if (Runtime.bIKDataInUse)
-				{
-					uint32 IKDataIndex = GET0_NUMBER;
-					uint16 IKBoneNum = GET0_NUMBER;
-					for (const TTuple<uint16, uint16>& BoneIdx : Reference.FirstLodGPUBonesCollection)
-					{
-						if (Runtime.IKData.Contains(BoneIdx.Key) && Runtime.IKData[BoneIdx.Key].
-							bIsInUsingWriteDataThisFrame && BoneIdx.Value != INDEX_NONE)
-						{
-							IKBoneNum++;
-						}
-
-						IKDataIndex += GET3_NUMBER;
-					}
-
-					if (IKBoneNum)
-					{
-						GlobalLibrary_RenderThread.BoneTransformParams.BoneSpaceAnimationIKIndex_RenderThread[Index] =
-							IKBoneNum;
-					}
-
-					CriticalSection.Lock();
-					GlobalLibrary_RenderThread.NumIKPixelCurrentFrame += IKBoneNum;
-					CriticalSection.Unlock();
-				}
 			}
-
-			Runtime.bIsVisible = false;
-			Runtime.bIKDataInUse = false;
-			// Runtime.IKData.Empty(); // Is now inside the minimal loop down below
 		}
-	}, EParallelForFlags::BackgroundPriority);
+
+		Runtime.bIsVisible = false;
+		Runtime.bIKDataInUse = false;
+		// Runtime.IKData.Empty(); // Is now inside the minimal loop down below
+	});
 
 	if (!GlobalLibrary_RenderThread.NumMeshesVisibleCurrentFrame)
 	{
@@ -1429,43 +1403,41 @@ void ATurboSequence_Manager_Lf::SolveMeshes_RenderThread(FRHICommandListImmediat
 				}
 			}
 		}
-	}, EParallelForFlags::BackgroundPriority);
+	});
 }
 
 void ATurboSequence_Manager_Lf::AddInstanceToUpdateGroup_RawID_Concurrent(const int32 GroupIndex, int32 MeshID)
 {
-	{
-		FScopeLock Lock(&Instance->GetThreadContext()->CriticalSection);
+	FScopeLock Lock(&Instance->GetThreadContext()->CriticalSection);
 
-		if (!GlobalLibrary.UpdateGroups.IsValidIndex(GroupIndex))
+	if (!GlobalLibrary.UpdateGroups.IsValidIndex(GroupIndex))
+	{
+		GlobalLibrary.UpdateGroups.SetNum(GroupIndex + GET1_NUMBER);
+	}
+
+	FTurboSequence_UpdateGroup_Lf& Group = GlobalLibrary.UpdateGroups[GroupIndex];
+
+	if (!Group.RawIDData.Contains(MeshID))
+	{
+		Group.RawIDData.Add(MeshID, Group.RawIDData.Num());
+		Group.RawIDs.Add(MeshID);
+		if (GlobalLibrary.MeshIDToMinimalData.Contains(MeshID))
 		{
-			GlobalLibrary.UpdateGroups.SetNum(GroupIndex + GET1_NUMBER);
+			if (!Group.MeshIDToMinimal.Contains(GlobalLibrary.MeshIDToMinimalData[MeshID]))
+			{
+				Group.MeshIDToMinimal.Add(GlobalLibrary.MeshIDToMinimalData[MeshID],
+				                          FIntVector2(GET1_NUMBER, Group.MeshIDToMinimal.Num()));
+				Group.RawMinimalData.Add(GlobalLibrary.MeshIDToMinimalData[MeshID]);
+			}
+			else
+			{
+				Group.MeshIDToMinimal[GlobalLibrary.MeshIDToMinimalData[MeshID]].X++;
+			}
 		}
 
-		FTurboSequence_UpdateGroup_Lf& Group = GlobalLibrary.UpdateGroups[GroupIndex];
-
-		if (!Group.RawIDData.Contains(MeshID))
+		if (GlobalLibrary.RuntimeSkinnedMeshes.Contains(MeshID))
 		{
-			Group.RawIDData.Add(MeshID, Group.RawIDData.Num());
-			Group.RawIDs.Add(MeshID);
-			if (GlobalLibrary.MeshIDToMinimalData.Contains(MeshID))
-			{
-				if (!Group.MeshIDToMinimal.Contains(GlobalLibrary.MeshIDToMinimalData[MeshID]))
-				{
-					Group.MeshIDToMinimal.Add(GlobalLibrary.MeshIDToMinimalData[MeshID],
-					                          FIntVector2(GET1_NUMBER, Group.MeshIDToMinimal.Num()));
-					Group.RawMinimalData.Add(GlobalLibrary.MeshIDToMinimalData[MeshID]);
-				}
-				else
-				{
-					Group.MeshIDToMinimal[GlobalLibrary.MeshIDToMinimalData[MeshID]].X++;
-				}
-			}
-
-			if (GlobalLibrary.RuntimeSkinnedMeshes.Contains(MeshID))
-			{
-				GlobalLibrary.RuntimeSkinnedMeshes[MeshID].UpdateGroupIndex = GroupIndex;
-			}
+			GlobalLibrary.RuntimeSkinnedMeshes[MeshID].UpdateGroupIndex = GroupIndex;
 		}
 	}
 }
@@ -1513,55 +1485,52 @@ void ATurboSequence_Manager_Lf::AddInstanceToUpdateGroup_Concurrent(const int32 
 
 void ATurboSequence_Manager_Lf::RemoveInstanceFromUpdateGroup_RawID_Concurrent(const int32 GroupIndex, int32 MeshID)
 {
-	//int32 RawIndexToRemove = INDEX_NONE;
+	FScopeLock Lock(&Instance->GetThreadContext()->CriticalSection);
+
+	if (GlobalLibrary.UpdateGroups.IsValidIndex(GroupIndex))
 	{
-		FScopeLock Lock(&Instance->GetThreadContext()->CriticalSection);
+		FTurboSequence_UpdateGroup_Lf& Group = GlobalLibrary.UpdateGroups[GroupIndex];
 
-		if (GlobalLibrary.UpdateGroups.IsValidIndex(GroupIndex))
+		if (Group.RawIDData.Contains(MeshID))
 		{
-			FTurboSequence_UpdateGroup_Lf& Group = GlobalLibrary.UpdateGroups[GroupIndex];
+			const int32 RawIndexToRemove = Group.RawIDData[MeshID];
 
-			if (Group.RawIDData.Contains(MeshID))
+			Group.RawIDData.Remove(MeshID);
+			Group.RawIDs.RemoveAt(RawIndexToRemove);
+
+			for (TTuple<int32, int32>& Data : Group.RawIDData)
 			{
-				const int32 RawIndexToRemove = Group.RawIDData[MeshID];
-
-				Group.RawIDData.Remove(MeshID);
-				Group.RawIDs.RemoveAt(RawIndexToRemove);
-
-				for (TTuple<int32, int32>& Data : Group.RawIDData)
+				if (Data.Value > RawIndexToRemove)
 				{
-					if (Data.Value > RawIndexToRemove)
-					{
-						Data.Value--;
-					}
+					Data.Value--;
 				}
+			}
 
-				if (GlobalLibrary.MeshIDToMinimalData.Contains(MeshID) && Group.MeshIDToMinimal.Contains(
-					GlobalLibrary.MeshIDToMinimalData[MeshID]))
+			if (GlobalLibrary.MeshIDToMinimalData.Contains(MeshID) && Group.MeshIDToMinimal.Contains(
+				GlobalLibrary.MeshIDToMinimalData[MeshID]))
+			{
+				Group.MeshIDToMinimal[GlobalLibrary.MeshIDToMinimalData[MeshID]].X--;
+				if (Group.MeshIDToMinimal[GlobalLibrary.MeshIDToMinimalData[MeshID]].X <= GET0_NUMBER)
 				{
-					Group.MeshIDToMinimal[GlobalLibrary.MeshIDToMinimalData[MeshID]].X--;
-					if (Group.MeshIDToMinimal[GlobalLibrary.MeshIDToMinimalData[MeshID]].X <= GET0_NUMBER)
+					const int32 MinimalIndexToRemove = Group.MeshIDToMinimal[GlobalLibrary.MeshIDToMinimalData[
+						MeshID]].Y;
+
+					Group.MeshIDToMinimal.Remove(GlobalLibrary.MeshIDToMinimalData[MeshID]);
+					Group.RawMinimalData.RemoveAt(MinimalIndexToRemove);
+
+					for (TTuple<FTurboSequence_MinimalMeshData_Lf, FIntVector2>& Data : Group.MeshIDToMinimal)
 					{
-						const int32 MinimalIndexToRemove = Group.MeshIDToMinimal[GlobalLibrary.MeshIDToMinimalData[
-							MeshID]].Y;
-
-						Group.MeshIDToMinimal.Remove(GlobalLibrary.MeshIDToMinimalData[MeshID]);
-						Group.RawMinimalData.RemoveAt(MinimalIndexToRemove);
-
-						for (TTuple<FTurboSequence_MinimalMeshData_Lf, FIntVector2>& Data : Group.MeshIDToMinimal)
+						if (Data.Value.Y > MinimalIndexToRemove)
 						{
-							if (Data.Value.Y > MinimalIndexToRemove)
-							{
-								Data.Value.Y--;
-							}
+							Data.Value.Y--;
 						}
 					}
 				}
+			}
 
-				if (GlobalLibrary.RuntimeSkinnedMeshes.Contains(MeshID))
-				{
-					GlobalLibrary.RuntimeSkinnedMeshes[MeshID].UpdateGroupIndex = INDEX_NONE;
-				}
+			if (GlobalLibrary.RuntimeSkinnedMeshes.Contains(MeshID))
+			{
+				GlobalLibrary.RuntimeSkinnedMeshes[MeshID].UpdateGroupIndex = INDEX_NONE;
 			}
 		}
 	}
@@ -1580,30 +1549,26 @@ void ATurboSequence_Manager_Lf::RemoveInstanceFromUpdateGroup_Concurrent(const i
 
 int32 ATurboSequence_Manager_Lf::GetNumMeshDataInUpdateGroup_Concurrent(const int32 GroupIndex)
 {
+	FScopeLock Lock(&Instance->GetThreadContext()->CriticalSection);
+
+	if (!GlobalLibrary.UpdateGroups.IsValidIndex(GroupIndex))
 	{
-		FScopeLock Lock(&Instance->GetThreadContext()->CriticalSection);
-
-		if (!GlobalLibrary.UpdateGroups.IsValidIndex(GroupIndex))
-		{
-			return INDEX_NONE;
-		}
-
-		return GlobalLibrary.UpdateGroups[GroupIndex].MeshIDToMinimal.Num();
+		return INDEX_NONE;
 	}
+
+	return GlobalLibrary.UpdateGroups[GroupIndex].MeshIDToMinimal.Num();
 }
 
 int32 ATurboSequence_Manager_Lf::GetNumMeshIDsInUpdateGroup_RawID_Concurrent(const int32 GroupIndex)
 {
+	FScopeLock Lock(&Instance->GetThreadContext()->CriticalSection);
+
+	if (!GlobalLibrary.UpdateGroups.IsValidIndex(GroupIndex))
 	{
-		FScopeLock Lock(&Instance->GetThreadContext()->CriticalSection);
-
-		if (!GlobalLibrary.UpdateGroups.IsValidIndex(GroupIndex))
-		{
-			return INDEX_NONE;
-		}
-
-		return GlobalLibrary.UpdateGroups[GroupIndex].RawIDData.Num();
+		return INDEX_NONE;
 	}
+
+	return GlobalLibrary.UpdateGroups[GroupIndex].RawIDData.Num();
 }
 
 FTurboSequence_MinimalMeshData_Lf ATurboSequence_Manager_Lf::GetMeshDataInUpdateGroupFromIndex_Concurrent(
@@ -1911,6 +1876,7 @@ FTurboSequence_AnimMinimalCollection_Lf ATurboSequence_Manager_Lf::PlayAnimation
 	const FTurboSequence_MinimalMeshData_Lf& MeshData, UAnimSequence* Animation,
 	const FTurboSequence_AnimPlaySettings_Lf& AnimSettings)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(ATurboSequence_Manager_Lf::PlayAnimation_Concurrent);
 	if (MeshData.IsMeshDataValid())
 	{
 		FTurboSequence_AnimMinimalCollection_Lf Data = FTurboSequence_AnimMinimalCollection_Lf(true);
@@ -1954,6 +1920,7 @@ FTurboSequence_AnimMinimalBlendSpaceCollection_Lf ATurboSequence_Manager_Lf::Pla
 	const FTurboSequence_MinimalMeshData_Lf& MeshData, UBlendSpace* BlendSpace,
 	const FTurboSequence_AnimPlaySettings_Lf AnimSettings)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(ATurboSequence_Manager_Lf::PlayBlendSpace_Concurrent);
 	if (MeshData.IsMeshDataValid())
 	{
 		FTurboSequence_AnimMinimalBlendSpaceCollection_Lf Data =
@@ -2020,6 +1987,7 @@ UAnimSequence* ATurboSequence_Manager_Lf::GetHighestPriorityPlayingAnimation_Raw
 bool ATurboSequence_Manager_Lf::TweakAnimation_Concurrent(const FTurboSequence_AnimPlaySettings_Lf TweakSettings,
                                                           const FTurboSequence_AnimMinimalData_Lf& AnimationData)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(ATurboSequence_Manager_Lf::TweakAnimation_Concurrent);
 	if (!GlobalLibrary.RuntimeSkinnedMeshes.Contains(AnimationData.BelongsToMeshID))
 	{
 		return false;
@@ -2075,6 +2043,7 @@ bool ATurboSequence_Manager_Lf::TweakBlendSpace_RawID_Concurrent(int32 MeshID,
 bool ATurboSequence_Manager_Lf::TweakBlendSpace_Concurrent(
 	const FTurboSequence_AnimMinimalBlendSpaceCollection_Lf& BlendSpaceData, const FVector3f WantedPosition)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(ATurboSequence_Manager_Lf::TweakBlendSpace_Concurrent);
 	if (BlendSpaceData.IsAnimCollectionValid())
 	{
 		bool bValid = TweakBlendSpace_RawID_Concurrent(BlendSpaceData.RootMotionMesh.BelongsToMeshID,

--- a/Source/TurboSequence_Lf/Private/TurboSequence_Utility_Lf.cpp
+++ b/Source/TurboSequence_Lf/Private/TurboSequence_Utility_Lf.cpp
@@ -183,6 +183,7 @@ uint32 FTurboSequence_Utility_Lf::CreateRenderer(FSkinnedMeshReference_Lf& Refer
 void FTurboSequence_Utility_Lf::UpdateCameras(TArray<FCameraView_Lf>& OutView, const UWorld* InWorld,
                                               const TArray<FTurboSequence_CameraInfo_Lf>& CustomCameraInfo)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::UpdateCameras);
 	const bool bHasCustomCameraData = static_cast<bool>(CustomCameraInfo.Num());
 	const bool bIsSinglePlayer = UGameplayStatics::GetNumPlayerControllers(InWorld) < GET2_NUMBER &&
 		CustomCameraInfo.Num() < GET2_NUMBER;
@@ -195,8 +196,8 @@ void FTurboSequence_Utility_Lf::UpdateCameras(TArray<FCameraView_Lf>& OutView, c
 	for (int32 ViewIdx = GET0_NUMBER; ViewIdx < MaxNumberPlayerControllers; ++ViewIdx)
 	{
 		FMinimalViewInfo PlayerMinimalViewInfo = FMinimalViewInfo();
-		FVector2D LocalPlayerSize = FVector2D(0,0);
-		FVector2D ViewportSize = FVector2D(0,0);
+		FVector2D LocalPlayerSize = FVector2D(0, 0);
+		FVector2D ViewportSize = FVector2D(0, 0);
 		float Fov = 90;
 		TEnumAsByte<enum EAspectRatioAxisConstraint> ConstraintType;
 		if (!bHasCustomCameraData)
@@ -280,6 +281,7 @@ void FTurboSequence_Utility_Lf::UpdateCameras_1(TArray<FCameraView_Lf>& OutViews
                                                 const UWorld* InWorld, float DeltaTime,
                                                 const TArray<FTurboSequence_CameraInfo_Lf>& CustomCameraInfo)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::UpdateCameras_1);
 	UpdateCameras(OutViews, InWorld, CustomCameraInfo);
 	float Interpolation = GET1_NUMBER; //GET2_NUMBER + DeltaTime * GET4_NUMBER;
 	uint8 NumCameraViews = OutViews.Num();
@@ -312,6 +314,7 @@ void FTurboSequence_Utility_Lf::UpdateCameras_1(TArray<FCameraView_Lf>& OutViews
 void FTurboSequence_Utility_Lf::UpdateCameras_2(TMap<uint8, FTransform>& OutLastFrameCameraTransforms,
                                                 const TArray<FCameraView_Lf>& CameraViews)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::UpdateCameras_2);
 	uint8 MaxNumberLastFrameCameras = FMath::Max(OutLastFrameCameraTransforms.Num(), CameraViews.Num());
 	for (uint8 i = GET0_NUMBER; i < MaxNumberLastFrameCameras; ++i)
 	{
@@ -419,6 +422,7 @@ void FTurboSequence_Utility_Lf::CreateTurboSequenceReference(FSkinnedMeshGlobalL
                                                              const TObjectPtr<UTurboSequence_MeshAsset_Lf> FromAsset,
                                                              const TObjectPtr<UWorld> InWorld)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::CreateTurboSequenceReference);
 	if (!IsValid(FromAsset))
 	{
 		return;
@@ -495,6 +499,7 @@ void FTurboSequence_Utility_Lf::CreateLevelOfDetails(FSkinnedMeshReference_Lf& R
                                                      const TObjectPtr<UTurboSequence_MeshAsset_Lf> FromAsset,
                                                      bool bIsMeshDataEvaluationFunction)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::CreateLevelOfDetails);
 	if (bIsMeshDataEvaluationFunction)
 	{
 		FromAsset->MeshData.Empty();
@@ -645,6 +650,7 @@ void FTurboSequence_Utility_Lf::CreateGPUBones(FSkinnedMeshReferenceLodElement_L
                                                const TObjectPtr<UTurboSequence_MeshAsset_Lf> Asset,
                                                bool bIsMeshDataEvaluation)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::CreateGPUBones);
 	if (!LodElement.CPUBoneToGPUBoneIndicesMap.Num())
 	{
 		if (bIsMeshDataEvaluation)
@@ -717,6 +723,7 @@ void FTurboSequence_Utility_Lf::CreateBoneMaps(FSkinnedMeshGlobalLibrary_Lf& Lib
                                                FSkinnedMeshGlobalLibrary_RenderThread_Lf& Library_RenderThread,
                                                FCriticalSection& CriticalSection)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::CreateBoneMaps);
 	if (Library.PerReferenceData.Num())
 	{
 		const int16 PreviousNumCPUBones = Library.MaxNumCPUBones;
@@ -811,7 +818,7 @@ void FTurboSequence_Utility_Lf::CreateBoneMaps(FSkinnedMeshGlobalLibrary_Lf& Lib
 					}
 					CachedIndices[BaseIndex + i] = Data;
 				}
-			}, EParallelForFlags::BackgroundPriority);
+			});
 
 
 			if (!Reference.FirstLodGPUBonesCollection.Num() && bHasRenderState)
@@ -850,6 +857,7 @@ void FTurboSequence_Utility_Lf::CreateRawSkinWeightTextureBuffer(
 	const TObjectPtr<UTurboSequence_MeshAsset_Lf> FromAsset, const TFunction<void(bool bSuccess)>& PostCall,
 	const TObjectPtr<UWorld> World)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::CreateRawSkinWeightTextureBuffer);
 #if WITH_EDITOR
 	if (!IsValid(FromAsset->GlobalData))
 	{
@@ -1001,7 +1009,7 @@ void FTurboSequence_Utility_Lf::CreateRawSkinWeightTextureBuffer(
 				RealVertexIndex * FTurboSequence_Helper_Lf::NumSkinWeightPixels +
 				FTurboSequence_Helper_Lf::NumSkinWeightPixels - GET1_NUMBER] = PerVertexCustomData_0;
 		}
-	}, EParallelForFlags::BackgroundPriority);
+	});
 
 	const int32 Slice = FMath::Min(
 		FMath::CeilToInt(
@@ -1089,6 +1097,7 @@ void FTurboSequence_Utility_Lf::CreateInverseReferencePose(FSkinnedMeshGlobalLib
                                                            FSkinnedMeshGlobalLibrary_RenderThread_Lf&
                                                            Library_RenderThread, FCriticalSection& CriticalSection)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::CreateInverseReferencePose);
 	int32 NumReferences = Library.PerReferenceData.Num();
 	TArray<FVector4f> InvRefPoseData;
 
@@ -1133,7 +1142,7 @@ void FTurboSequence_Utility_Lf::CreateInverseReferencePose(FSkinnedMeshGlobalLib
 					InvRefPoseData[InvRestPoseBaseIndex + BoneIdx * GET3_NUMBER + M] = Row;
 				}
 			}
-		}, EParallelForFlags::BackgroundPriority);
+		});
 	}
 
 	ENQUEUE_RENDER_COMMAND(TurboSequence_AddInverseReferencePoses_Lf)(
@@ -1171,6 +1180,7 @@ int32 FTurboSequence_Utility_Lf::AddAnimationToLibraryChunked(FSkinnedMeshGlobal
                                                               const FSkinnedMeshRuntime_Lf& Runtime,
                                                               const FAnimationMetaData_Lf& Animation)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::AddAnimationToLibraryChunked);
 	// Slow...
 	FScopeLock Lock(&CriticalSection);
 
@@ -1412,6 +1422,7 @@ void FTurboSequence_Utility_Lf::UpdateInstanceTransform_Concurrent(FSkinnedMeshR
                                                                    const FTransform& WorldSpaceTransform,
                                                                    const bool bForce)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::UpdateInstanceTransform_Concurrent);
 	if (bForce || Runtime.EIsVisibleOverride !=
 		ETurboSequence_IsVisibleOverride_Lf::ScaleToZero)
 	{
@@ -1448,6 +1459,7 @@ void FTurboSequence_Utility_Lf::AddRenderInstance(FSkinnedMeshReference_Lf& Refe
                                                   FCriticalSection& CriticalSection,
                                                   const FTransform& WorldSpaceTransform)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::AddRenderInstance);
 	FScopeLock Lock(&CriticalSection);
 
 	FRenderData_Lf& RenderData = Reference.RenderData[Runtime.MaterialsHash];
@@ -1498,6 +1510,7 @@ void FTurboSequence_Utility_Lf::RemoveRenderInstance(FSkinnedMeshReference_Lf& R
                                                      FCriticalSection& CriticalSection,
                                                      FSkinnedMeshGlobalLibrary_Lf& Library)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::RemoveRenderInstance);
 	FScopeLock Lock(&CriticalSection);
 
 	FRenderData_Lf& RenderData = Reference.RenderData[Runtime.MaterialsHash];
@@ -1638,6 +1651,7 @@ void FTurboSequence_Utility_Lf::UpdateCullingAndLevelOfDetail(FSkinnedMeshRuntim
                                                               TObjectPtr<UTurboSequence_ThreadContext_Lf> ThreadContext,
                                                               FSkinnedMeshGlobalLibrary_Lf& Library)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::UpdateCullingAndLevelOfDetail);
 	float ClosestCameraDistance = GET_INFINITY;
 	const FVector& ComponentLocation = Runtime.WorldSpaceTransform.GetLocation();
 	for (const FCameraView_Lf& CameraView : CameraViews)
@@ -1764,6 +1778,7 @@ void FTurboSequence_Utility_Lf::UpdateCameraRendererBounds(FRenderData_Lf& Rende
 
 uint32 FTurboSequence_Utility_Lf::GetAnimationLayerGroupHash(const TArray<FTurboSequence_BoneLayer_Lf>& Layers)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::GetAnimationLayerGroupHash);
 	uint32 Hash = GET0_NUMBER;
 	for (const FTurboSequence_BoneLayer_Lf& Layer : Layers)
 	{
@@ -1814,6 +1829,7 @@ uint32 FTurboSequence_Utility_Lf::GenerateAnimationLayerMask(FAnimationMetaData_
                                                              const FSkinnedMeshReference_Lf& Reference,
                                                              bool bGenerateLayers)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::GenerateAnimationLayerMask);
 	int16 NumCPUBones = Reference.NumCPUBones;
 
 	if (bGenerateLayers)
@@ -1949,6 +1965,7 @@ bool FTurboSequence_Utility_Lf::MergeAnimationLayerMask(const TArray<uint16>& An
                                                         uint32 AnimationLayerHash, FCriticalSection& CriticalSection,
                                                         FSkinnedMeshGlobalLibrary_Lf& Library, bool bIsAdd)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::MergeAnimationLayerMask);
 	FScopeLock Lock(&CriticalSection);
 
 	bool bEditedLayer = false;
@@ -2056,6 +2073,7 @@ void FTurboSequence_Utility_Lf::UpdateAnimationLayerMasks(FCriticalSection& Crit
                                                           FSkinnedMeshGlobalLibrary_RenderThread_Lf&
                                                           Library_RenderThread)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::UpdateAnimationLayerMasks);
 	bool bEditedLayers = false;
 	if (Library.AnimationBlendLayerMasksRuntimeDirty.Num())
 	{
@@ -2147,34 +2165,21 @@ void FTurboSequence_Utility_Lf::UpdateAnimationLayerMasks(FCriticalSection& Crit
 									GET0_NUMBER;
 							}
 						}
-					}, EParallelForFlags::BackgroundPriority);
+					});
 				});
 
 			const int32 NumMeshes = Library.RuntimeSkinnedMeshesHashMap.Num();
-			int32 NumMeshesPerThread = FMath::CeilToInt(
-				static_cast<float>(NumMeshes) / static_cast<float>(NumThreads));
-			ParallelFor(NumThreads, [&](int32 ThreadsIndex)
+			ParallelFor(NumMeshes, [&](int32 Index)
 			{
-				const int32 MeshBaseIndex = ThreadsIndex * NumMeshesPerThread;
-				const int32 MeshBaseNum = MeshBaseIndex + NumMeshesPerThread;
+				FSkinnedMeshRuntime_Lf& Runtime = Library.RuntimeSkinnedMeshes[Library.
+					RuntimeSkinnedMeshesHashMap[Index]];
 
-				for (int32 Index = MeshBaseIndex; Index < MeshBaseNum; ++Index)
+				for (FAnimationMetaData_Lf& Animation : Runtime.AnimationMetaData)
 				{
-					if (Index >= NumMeshes)
-					{
-						break;
-					}
-
-					FSkinnedMeshRuntime_Lf& Runtime = Library.RuntimeSkinnedMeshes[Library.
-						RuntimeSkinnedMeshesHashMap[Index]];
-
-					for (FAnimationMetaData_Lf& Animation : Runtime.AnimationMetaData)
-					{
-						UpdatedAnimationLayerMaskIndex(Animation, Runtime,
-						                               Library, Library_RenderThread);
-					}
+					UpdatedAnimationLayerMaskIndex(Animation, Runtime,
+					                               Library, Library_RenderThread);
 				}
-			}, EParallelForFlags::BackgroundPriority);
+			});
 		}
 		else
 		{
@@ -2231,7 +2236,7 @@ void FTurboSequence_Utility_Lf::UpdateAnimationLayerMasks(FCriticalSection& Crit
 							Library_RenderThread.BoneTransformParams.AnimationLayers_RenderThread[i] = GET0_NUMBER;
 						}
 					}
-				}, EParallelForFlags::BackgroundPriority);
+				});
 			});
 	}
 }
@@ -2242,6 +2247,7 @@ void FTurboSequence_Utility_Lf::AddAnimation(FSkinnedMeshRuntime_Lf& Runtime, co
                                              const TObjectPtr<UTurboSequence_ThreadContext_Lf>& ThreadContext,
                                              FSkinnedMeshGlobalLibrary_Lf& Library)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::AddAnimation);
 	FScopeLock Lock(&ThreadContext->CriticalSection);
 	{
 		TArray<uint16> Layers;
@@ -2302,6 +2308,7 @@ void FTurboSequence_Utility_Lf::RemoveAnimation(FSkinnedMeshRuntime_Lf& Runtime,
                                                 FSkinnedMeshGlobalLibrary_RenderThread_Lf& Library_RenderThread,
                                                 int32 Index)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::RemoveAnimation);
 	ThreadContext->CriticalSection.Lock();
 	const uint32 AnimationID = Runtime.AnimationMetaData[Index].AnimationID;
 	ThreadContext->CriticalSection.Unlock();
@@ -2349,6 +2356,7 @@ bool FTurboSequence_Utility_Lf::RefreshBlendSpaceState(const TObjectPtr<UBlendSp
                                                        FAnimationBlendSpaceData_Lf& Data, float DeltaTime,
                                                        FCriticalSection& CriticalSection)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::RefreshBlendSpaceState);
 	Data.Tick = FAnimTickRecord(BlendSpace, FVector(Data.CurrentPosition), Data.CachedBlendSampleData,
 	                            Data.BlendFilter, true, 1.0f, true, true, 1.0f, Data.CurrentTime, Data.Record);
 	const TArray<FName> MarkerNames;
@@ -2380,6 +2388,7 @@ FTurboSequence_AnimMinimalBlendSpace_Lf FTurboSequence_Utility_Lf::PlayBlendSpac
 	const FTurboSequence_AnimPlaySettings_Lf& AnimSettings, float OverrideWeight, float OverrideStartTime,
 	float OverrideEndTime)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::PlayBlendSpace);
 	FAnimationBlendSpaceData_Lf Data = FAnimationBlendSpaceData_Lf();
 	FTurboSequence_AnimMinimalBlendSpace_Lf BlendSpaceData = FTurboSequence_AnimMinimalBlendSpace_Lf(true);
 	BlendSpaceData.BlendSpace = BlendSpace;
@@ -2487,6 +2496,7 @@ uint32 FTurboSequence_Utility_Lf::PlayAnimation(const FSkinnedMeshReference_Lf& 
                                                 float OverrideStartTime, float OverrideEndTime,
                                                 uint32 OverrideAnimationID)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::PlayAnimation);
 	// TObjectPtr<USkeleton> Skeleton = Reference.DataAsset->GetSkeleton();
 	//
 	// ThreadContext->CriticalSection.Lock();
@@ -2633,6 +2643,7 @@ void FTurboSequence_Utility_Lf::UpdateBlendSpaces(FSkinnedMeshRuntime_Lf& Runtim
                                                   FSkinnedMeshGlobalLibrary_RenderThread_Lf& Library_RenderThread,
                                                   const FSkinnedMeshReference_Lf& Reference)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::UpdateBlendSpaces);
 	for (TTuple<TObjectPtr<UBlendSpace>, FAnimationBlendSpaceData_Lf>& BlendSpace : Runtime.
 	     AnimationBlendSpaceMetaData)
 	{
@@ -2692,6 +2703,7 @@ bool FTurboSequence_Utility_Lf::TweakAnimation(FSkinnedMeshRuntime_Lf& Runtime,
                                                const FTurboSequence_AnimPlaySettings_Lf& Settings, uint32 AnimationID,
                                                const FSkinnedMeshReference_Lf& Reference)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::TweakAnimation);
 	if (!Runtime.AnimationIDs.Contains(AnimationID))
 	{
 		return false;
@@ -2725,6 +2737,7 @@ void FTurboSequence_Utility_Lf::SolveAnimations(FSkinnedMeshRuntime_Lf& Runtime,
                                                 float DeltaTime, int32 CurrentFrameCount,
                                                 const TObjectPtr<UTurboSequence_ThreadContext_Lf>& ThreadContext)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::SolveAnimations);
 	if (CurrentFrameCount == Runtime.LastFrameAnimationSolved)
 	{
 		return;
@@ -2997,6 +3010,7 @@ FTransform FTurboSequence_Utility_Lf::BendBoneFromAnimations(uint16 BoneIndex, c
                                                              const FSkinnedMeshReference_Lf& Reference,
                                                              const FSkinnedMeshGlobalLibrary_Lf& Library)
 {
+	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::BendBoneFromAnimations);
 	const FReferenceSkeleton& ReferenceSkeleton = GetReferenceSkeleton(Runtime.DataAsset);
 
 	FTransform OutAtom = FTransform::Identity;


### PR DESCRIPTION
Instead of calculating NumThreads, we can let ParallelFor do that by passing NumMeshes. Doing this will allow it to fully saturate the background threads and reduces the game thread wait time that happens at the end of the loop while it waits for the other threads to finish their work. This contains no functionality changes.

Notice that the overall time is improved, and ParallelFor.Wait time is greatly reduced :)

Before:
<img width="1714" height="319" alt="ParallelFor_Before" src="https://github.com/user-attachments/assets/1173a788-2bd9-4e4c-bc4d-83c4919aa70f" />

After:
<img width="1718" height="399" alt="ParallelFor_After" src="https://github.com/user-attachments/assets/675e357a-b912-41af-8432-f26819eeb972" />

Also adds profiler scopes to important functions so that they show up in Insights and minor Rider formatting changes