### PR TITLE
Skip adding animations to library when they have no weight

### DIFF
--- a/Source/TurboSequence_Lf/Private/TurboSequence_Utility_Lf.cpp
+++ b/Source/TurboSequence_Lf/Private/TurboSequence_Utility_Lf.cpp
@@ -2825,6 +2825,9 @@ void FTurboSequence_Utility_Lf::SolveAnimations(FSkinnedMeshRuntime_Lf& Runtime,
 			}
 		}
 
+		if (Animation.FinalAnimationWeight <= 0.f)
+			continue;
+
 		int32 CPUPoses;
 		int32 GPUPoses = AddAnimationToLibraryChunked(Library, ThreadContext->CriticalSection, CPUPoses,
 		                                              Runtime, Animation);


### PR DESCRIPTION
_Disclosure: I am managing animation timing from outside TS, in order to support serialization and replication better._

When many new animations are played in a single frame, AddAnimationToLibraryChunked becomes a bottleneck due to the required thread locks. This can sometimes be quite drastic. We can cut down on this by skipping any animation that has no weight, and therefor, wouldn't play anyway.
