### PR TITLE
Add functionality for setting self managed AnimationTime by AnimSequence

### DIFF
--- a/Source/TurboSequence_Lf/Private/TurboSequence_Manager_Lf.cpp
+++ b/Source/TurboSequence_Lf/Private/TurboSequence_Manager_Lf.cpp
@@ -85,24 +85,24 @@ void ATurboSequence_Manager_Lf::Tick(float DeltaTime)
 			{
 				continue;
 			}
-			
+
 			if (IsValid(IsmComponent))
 			{
 				for (TTuple<int32, int32>& InstanceID : RenderData.Value.InstanceMap)
 				{
 					// Real Index
 					const uint32 InstanceIndex = InstanceID.Value;
-					
+
 					// Locations
-					const FQuat Quat = FQuat(RenderData.Value.ParticleRotations[InstanceIndex].X, 
-						RenderData.Value.ParticleRotations[InstanceIndex].Y, 
-						RenderData.Value.ParticleRotations[InstanceIndex].Z, 
-						RenderData.Value.ParticleRotations[InstanceIndex].W);
-					const FTransform& Transform = FTransform(Quat, 
-						FVector(RenderData.Value.ParticlePositions[InstanceIndex]),
-						FVector(RenderData.Value.ParticleScales[InstanceIndex]));
+					const FQuat Quat = FQuat(RenderData.Value.ParticleRotations[InstanceIndex].X,
+					                         RenderData.Value.ParticleRotations[InstanceIndex].Y,
+					                         RenderData.Value.ParticleRotations[InstanceIndex].Z,
+					                         RenderData.Value.ParticleRotations[InstanceIndex].W);
+					const FTransform& Transform = FTransform(Quat,
+					                                         FVector(RenderData.Value.ParticlePositions[InstanceIndex]),
+					                                         FVector(RenderData.Value.ParticleScales[InstanceIndex]));
 					IsmComponent->UpdateInstanceTransform(InstanceIndex, Transform, true, true, false);
-					
+
 					// Custom Data
 					if (RenderData.Value.ParticleCustomDataIsm.IsValidIndex(InstanceIndex))
 					{
@@ -111,8 +111,9 @@ void ATurboSequence_Manager_Lf::Tick(float DeltaTime)
 							for (int32 i = GET0_NUMBER; i < FTurboSequence_Helper_Lf::NumInstanceCustomData; i++)
 							{
 								const int32 CustomDataIndex = InstanceIndex * FTurboSequence_Helper_Lf::NumInstanceCustomData + i;
-							
-								RenderData.Value.ParticleCustomDataIsm[InstanceIndex][i] = RenderData.Value.ParticleCustomData[CustomDataIndex];
+
+								RenderData.Value.ParticleCustomDataIsm[InstanceIndex][i] = RenderData.Value.ParticleCustomData[
+									CustomDataIndex];
 							}
 							IsmComponent->SetCustomData(InstanceIndex, RenderData.Value.ParticleCustomDataIsm[InstanceIndex], true);
 						}
@@ -121,7 +122,7 @@ void ATurboSequence_Manager_Lf::Tick(float DeltaTime)
 				IsmComponent->MarkRenderInstancesDirty();
 				IsmComponent->MarkRenderStateDirty();
 				IsmComponent->MarkRenderDynamicDataDirty();
-				
+
 				RenderData.Value.bChangedLodCollectionThisFrame = false;
 				RenderData.Value.bChangedCustomDataCollectionThisFrame = false;
 				RenderData.Value.bChangedPositionCollectionThisFrame = false;
@@ -129,7 +130,7 @@ void ATurboSequence_Manager_Lf::Tick(float DeltaTime)
 				RenderData.Value.bChangedScaleCollectionThisFrame = false;
 
 				RenderData.Value.bChangedCollectionSizeThisFrame = false;
-				
+
 				continue;
 			}
 
@@ -143,7 +144,7 @@ void ATurboSequence_Manager_Lf::Tick(float DeltaTime)
 			                                  bChangedCollectionSizePreviousFrame);
 
 			if (RenderData.Value.bChangedCollectionSizePreviousFrame && !RenderData.Value.
-				bChangedCollectionSizeThisFrame)
+			                                                                        bChangedCollectionSizeThisFrame)
 			{
 				RenderData.Value.bChangedCollectionSizePreviousFrame = false;
 			}
@@ -156,21 +157,21 @@ void ATurboSequence_Manager_Lf::Tick(float DeltaTime)
 			}
 
 			if (RenderData.Value.bChangedCustomDataCollectionThisFrame || RenderData.Value.
-				bChangedCollectionSizeThisFrame)
+			                                                                         bChangedCollectionSizeThisFrame)
 			{
 				UNiagaraDataInterfaceArrayFunctionLibrary::SetNiagaraArrayFloat(
 					NiagaraComponent, *RenderData.Value.GetCustomDataName(), RenderData.Value.ParticleCustomData);
 			}
 
 			if (RenderData.Value.bChangedPositionCollectionThisFrame || RenderData.Value.
-				bChangedCollectionSizeThisFrame)
+			                                                                       bChangedCollectionSizeThisFrame)
 			{
 				UNiagaraDataInterfaceArrayFunctionLibrary::SetNiagaraArrayPosition(
 					NiagaraComponent, *RenderData.Value.GetPositionName(), RenderData.Value.ParticlePositions);
 			}
 
 			if (RenderData.Value.bChangedRotationCollectionThisFrame || RenderData.Value.
-				bChangedCollectionSizeThisFrame)
+			                                                                       bChangedCollectionSizeThisFrame)
 			{
 				UNiagaraDataInterfaceArrayFunctionLibrary::SetNiagaraArrayVector4(
 					NiagaraComponent, *RenderData.Value.GetRotationName(), RenderData.Value.ParticleRotations);
@@ -527,9 +528,9 @@ int32 ATurboSequence_Manager_Lf::AddSkinnedMeshInstance_GameThread(
 			}
 		}
 		const FTransform& InstanceTransform = Runtime.WorldSpaceTransform;
-		
+
 		FTurboSequence_Utility_Lf::AddRenderInstance(Reference, Runtime, ThreadContext->CriticalSection,
-		                                              Instance->RenderComponents, InstanceTransform);
+		                                             Instance->RenderComponents, InstanceTransform);
 
 
 		Runtime.LodIndex = INDEX_NONE;
@@ -623,7 +624,8 @@ bool ATurboSequence_Manager_Lf::RemoveSkinnedMeshInstance_GameThread(int32 MeshI
 	                                                     Library_RenderThread);
 
 	FSkinnedMeshReference_Lf& Reference = GlobalLibrary.PerReferenceData[Runtime.DataAsset];
-	FTurboSequence_Utility_Lf::RemoveRenderInstance(Reference, Runtime, ThreadContext->CriticalSection, GlobalLibrary, Instance->RenderComponents);
+	FTurboSequence_Utility_Lf::RemoveRenderInstance(Reference, Runtime, ThreadContext->CriticalSection, GlobalLibrary,
+	                                                Instance->RenderComponents);
 
 	if (const FRenderData_Lf& RenderData = Reference.RenderData[Runtime.MaterialsHash]; !RenderData.InstanceMap.Num())
 	{
@@ -1340,7 +1342,7 @@ void ATurboSequence_Manager_Lf::SolveMeshes_RenderThread(FRHICommandListImmediat
 								MeshParams.BoneSpaceAnimationIKData_RenderThread[CurrentIKDataIndex] = BoneIdx.Value;
 
 								const FMatrix& BoneMatrix = Runtime.IKData[BoneIdx.Key].IKWriteTransform.
-									ToMatrixWithScale();
+								                                                        ToMatrixWithScale();
 
 								for (int32 M = GET0_NUMBER; M < GET3_NUMBER; ++M)
 								{
@@ -1898,6 +1900,28 @@ FTurboSequence_AnimMinimalData_Lf ATurboSequence_Manager_Lf::PlayAnimation_RawID
 	return MinimalAnimation;
 }
 
+void ATurboSequence_Manager_Lf::SetSelfManagedAnimSequenceTime(
+	const FTurboSequence_MinimalMeshData_Lf& MeshData,
+	UAnimSequence* AnimSequence, float NewTime)
+{
+	auto SetMetaDataAnimTimeForMeshID = [AnimSequence, NewTime](int32 MeshID)
+	{
+		if (auto Runtime = GlobalLibrary.RuntimeSkinnedMeshes.Find(MeshID))
+		{
+			if (int32* Idx = Runtime->AnimSeqToMetaData.Find(AnimSequence))
+			{
+				Runtime->AnimationMetaData[*Idx].AnimationTime = NewTime;
+			}
+		}
+	};
+
+	SetMetaDataAnimTimeForMeshID(MeshData.RootMotionMeshID);
+	for (const int32 CustomMeshID : MeshData.CustomizableMeshIDs)
+	{
+		SetMetaDataAnimTimeForMeshID(CustomMeshID);
+	}
+}
+
 FTurboSequence_AnimMinimalBlendSpaceCollection_Lf ATurboSequence_Manager_Lf::PlayBlendSpace_Concurrent(
 	const FTurboSequence_MinimalMeshData_Lf& MeshData, UBlendSpace* BlendSpace,
 	const FTurboSequence_AnimPlaySettings_Lf AnimSettings)
@@ -2306,16 +2330,17 @@ bool ATurboSequence_Manager_Lf::GetIsMeshVisibleInCameraFrustum_Concurrent(
 	return false;
 }
 
-bool ATurboSequence_Manager_Lf::GetIsMeshVisibleInCameraFrustum_RawID_Concurrent(int32 MeshID, const bool bDetectBoundsCheckOnly)
+bool ATurboSequence_Manager_Lf::GetIsMeshVisibleInCameraFrustum_RawID_Concurrent(
+	int32 MeshID, const bool bDetectBoundsCheckOnly)
 {
-		if (GlobalLibrary.RuntimeSkinnedMeshes.Contains(MeshID))
-		{
-			const FSkinnedMeshRuntime_Lf& Runtime = GlobalLibrary.RuntimeSkinnedMeshes[MeshID];
-			const FSkinnedMeshReference_Lf& Reference = GlobalLibrary.PerReferenceData[Runtime.DataAsset];
-			return FTurboSequence_Utility_Lf::GetIsMeshVisible(Runtime, Reference, bDetectBoundsCheckOnly);
-		}
-		return false;
+	if (GlobalLibrary.RuntimeSkinnedMeshes.Contains(MeshID))
+	{
+		const FSkinnedMeshRuntime_Lf& Runtime = GlobalLibrary.RuntimeSkinnedMeshes[MeshID];
+		const FSkinnedMeshReference_Lf& Reference = GlobalLibrary.PerReferenceData[Runtime.DataAsset];
+		return FTurboSequence_Utility_Lf::GetIsMeshVisible(Runtime, Reference, bDetectBoundsCheckOnly);
 	}
+	return false;
+}
 
 bool ATurboSequence_Manager_Lf::GetReferencePoseTransform_Concurrent(FTransform& OutRefPoseTransform,
                                                                      const FTurboSequence_MinimalMeshData_Lf& MeshData,
@@ -2631,6 +2656,20 @@ bool ATurboSequence_Manager_Lf::SetCustomDataToInstance_Concurrent(const FTurboS
 	}
 
 	return bSuccess;
+}
+
+bool ATurboSequence_Manager_Lf::GetMetaDataForAnimSeq(
+	int32 MeshID, UAnimSequence* AnimSeq, FAnimationMetaData_Lf& OutMetaData)
+{
+	if (auto Runtime = GlobalLibrary.RuntimeSkinnedMeshes.Find(MeshID))
+	{
+		if (int32* Idx = Runtime->AnimSeqToMetaData.Find(AnimSeq))
+		{
+			OutMetaData = Runtime->AnimationMetaData[*Idx];
+			return true;
+		}
+	}
+	return false;
 }
 
 bool ATurboSequence_Manager_Lf::SetTransitionTsMeshToUEMesh_Concurrent(const int32 TsMeshID,

--- a/Source/TurboSequence_Lf/Private/TurboSequence_Utility_Lf.cpp
+++ b/Source/TurboSequence_Lf/Private/TurboSequence_Utility_Lf.cpp
@@ -90,12 +90,12 @@ uint32 FTurboSequence_Utility_Lf::CreateRenderer(FSkinnedMeshReference_Lf& Refer
 			Item.Materials = ConvertedMaterial;
 			RenderComponents[FromAsset].Renderer.Add(MaterialsHash, Item);
 		}
-		
+
 		// Set Nanite State
 		RenderComponents[FromAsset].Renderer[MaterialsHash].NiagaraRenderer->SetVariableBool(
-						*RenderData.GetUseNaniteName(), FromAsset->bUseNanite);
+			*RenderData.GetUseNaniteName(), FromAsset->bUseNanite);
 		RenderComponents[FromAsset].Renderer[MaterialsHash].NiagaraRenderer->SetVariableBool(
-						*FTurboSequence_Helper_Lf::NameNotUseNanite, !FromAsset->bUseNanite);
+			*FTurboSequence_Helper_Lf::NameNotUseNanite, !FromAsset->bUseNanite);
 
 
 		// Add the mesh to the component we just created
@@ -118,7 +118,7 @@ uint32 FTurboSequence_Utility_Lf::CreateRenderer(FSkinnedMeshReference_Lf& Refer
 					}
 					RenderComponents[FromAsset].Renderer[MaterialsHash].NiagaraRenderer->SetVariableStaticMesh(
 						*WantedMeshName, LodElement.Mesh);
-					
+
 					// if (!bNaniteMeshSet)
 					// {
 					// 	RenderComponents[FromAsset].NiagaraRenderer[MaterialsHash].NiagaraRenderer->SetVariableStaticMesh(
@@ -173,7 +173,10 @@ uint32 FTurboSequence_Utility_Lf::CreateRenderer(FSkinnedMeshReference_Lf& Refer
 				{
 					if (FromAsset->RenderMode == ETurboSequence_RenderMode_Lf::InstancedStaticMeshComponent)
 					{
-						UE_LOG(LogTurboSequence_Lf, Error, TEXT("Render mode InstancedStaticMeshComponent is not supported without Nanite ... please use Nanite, or switch to Render Mode NiagaraParticles in the mesh asset, Effected Asset is ->  %s"), *FromAsset->GetPathName())
+						UE_LOG(LogTurboSequence_Lf, Error,
+						       TEXT(
+							       "Render mode InstancedStaticMeshComponent is not supported without Nanite ... please use Nanite, or switch to Render Mode NiagaraParticles in the mesh asset, Effected Asset is ->  %s"
+						       ), *FromAsset->GetPathName())
 					}
 				}
 			}
@@ -184,7 +187,10 @@ uint32 FTurboSequence_Utility_Lf::CreateRenderer(FSkinnedMeshReference_Lf& Refer
 				{
 					// Color Nanite
 					//DataMode = 3.0f;
-					UE_LOG(LogTurboSequence_Lf, Error, TEXT("Vertex Color mode is not supported with Nanite Rendering ... please use the UV Mode, Effected Asset is ->  %s"), *FromAsset->GetPathName())
+					UE_LOG(LogTurboSequence_Lf, Error,
+					       TEXT(
+						       "Vertex Color mode is not supported with Nanite Rendering ... please use the UV Mode, Effected Asset is ->  %s"
+					       ), *FromAsset->GetPathName())
 				}
 			}
 			MaterialInstance->SetScalarParameterValue(
@@ -224,14 +230,13 @@ uint32 FTurboSequence_Utility_Lf::CreateRenderer(FSkinnedMeshReference_Lf& Refer
 			}
 		}
 
-		return MaterialsHash;	
+		return MaterialsHash;
 	}
 	else
 	{
-
 		UInstancedStaticMeshComponent* Renderer = Cast<UInstancedStaticMeshComponent>(
 			WorldActor->AddComponentByClass(UInstancedStaticMeshComponent::StaticClass(), false, FTransform::Identity,
-											false));
+			                                false));
 		Renderer->RegisterComponent();
 		Renderer->SetupAttachment(InstanceSceneComponent);
 		WorldActor->AddInstanceComponent(Renderer);
@@ -250,7 +255,8 @@ uint32 FTurboSequence_Utility_Lf::CreateRenderer(FSkinnedMeshReference_Lf& Refer
 			Renderer->SetHasPerInstancePrevTransforms(false);
 			Renderer->SetWorldTransform(FTransform::Identity);
 			// Renderer->SetStaticMesh(MeshData->GetStaticMesh());
-			Renderer->NumCustomDataFloats = FTurboSequence_Helper_Lf::NumInstanceCustomData; // Change it but keep in mind TS Needs the first 4
+			Renderer->NumCustomDataFloats = FTurboSequence_Helper_Lf::NumInstanceCustomData;
+			// Change it but keep in mind TS Needs the first 4
 			Renderer->SetVisibleInRayTracing(true);
 		}
 
@@ -285,7 +291,7 @@ uint32 FTurboSequence_Utility_Lf::CreateRenderer(FSkinnedMeshReference_Lf& Refer
 		for (const TTuple<uint8, FSkinnedMeshReferenceLodElement_Lf>& Lod : LevelOfDetails)
 		{
 			const FSkinnedMeshReferenceLodElement_Lf& LodElement = Lod.Value;
-			
+
 			if (LodElement.bIsRenderStateValid)
 			{
 				if (LodElement.GPUMeshIndex < FTurboSequence_Helper_Lf::NotVisibleMeshIndex)
@@ -298,7 +304,7 @@ uint32 FTurboSequence_Utility_Lf::CreateRenderer(FSkinnedMeshReference_Lf& Refer
 				}
 			}
 		}
-		
+
 		// Set the Materials
 		int32 NumMaterials = Materials.Num();
 		for (int32 MaterialIdx = GET0_NUMBER; MaterialIdx < NumMaterials; ++MaterialIdx)
@@ -332,13 +338,15 @@ uint32 FTurboSequence_Utility_Lf::CreateRenderer(FSkinnedMeshReference_Lf& Refer
 					{
 						DataMode = 1.0f;
 					}
-					
 				}
 				else
 				{
 					if (FromAsset->RenderMode == ETurboSequence_RenderMode_Lf::InstancedStaticMeshComponent)
 					{
-						UE_LOG(LogTurboSequence_Lf, Error, TEXT("Render mode InstancedStaticMeshComponent is not supported without Nanite ... please use Nanite, or switch to Render Mode NiagaraParticles in the mesh asset, Effected Asset is ->  %s"), *FromAsset->GetPathName())
+						UE_LOG(LogTurboSequence_Lf, Error,
+						       TEXT(
+							       "Render mode InstancedStaticMeshComponent is not supported without Nanite ... please use Nanite, or switch to Render Mode NiagaraParticles in the mesh asset, Effected Asset is ->  %s"
+						       ), *FromAsset->GetPathName())
 					}
 				}
 			}
@@ -349,7 +357,10 @@ uint32 FTurboSequence_Utility_Lf::CreateRenderer(FSkinnedMeshReference_Lf& Refer
 				{
 					// Color Nanite
 					//DataMode = 3.0f;
-					UE_LOG(LogTurboSequence_Lf, Error, TEXT("Vertex Color mode is not supported with Nanite Rendering ... please use the UV Mode, Effected Asset is ->  %s"), *FromAsset->GetPathName())
+					UE_LOG(LogTurboSequence_Lf, Error,
+					       TEXT(
+						       "Vertex Color mode is not supported with Nanite Rendering ... please use the UV Mode, Effected Asset is ->  %s"
+					       ), *FromAsset->GetPathName())
 				}
 			}
 			MaterialInstance->SetScalarParameterValue(
@@ -368,7 +379,7 @@ uint32 FTurboSequence_Utility_Lf::CreateRenderer(FSkinnedMeshReference_Lf& Refer
 				MaterialInstance;
 		}
 
-		return MaterialsHash;	
+		return MaterialsHash;
 	}
 }
 
@@ -752,7 +763,7 @@ void FTurboSequence_Utility_Lf::CreateLevelOfDetails(FSkinnedMeshReference_Lf& R
 				if (FromAsset->bUseNanite)
 				{
 					NumVerticesInstancedMesh = FromAsset->InstancedMeshes[i].StaticMesh->GetNumNaniteVertices();
-					
+
 					MeshData.NumNaniteVertices = NumVerticesInstancedMesh;
 				}
 				else
@@ -1227,9 +1238,10 @@ void FTurboSequence_Utility_Lf::CreateRawSkinWeightTextureBuffer(
 	});
 
 	const int32 Slice = FMath::Max(FMath::Min(
-		FMath::CeilToInt(
-			static_cast<float>(FromAsset->GlobalData->CachedMeshDataCreationSettingsParams.SettingsInput.Num()) /
-			static_cast<float>(GET128_NUMBER * GET128_NUMBER)), 1023), 1);
+		                               FMath::CeilToInt(
+			                               static_cast<float>(FromAsset->GlobalData->CachedMeshDataCreationSettingsParams.
+			                                                             SettingsInput.Num()) /
+			                               static_cast<float>(GET128_NUMBER * GET128_NUMBER)), 1023), 1);
 
 	FromAsset->GlobalData->SkinWeightTexture->Init(GET128_NUMBER, GET128_NUMBER, Slice, PF_FloatRGBA);
 	FromAsset->GlobalData->SkinWeightTexture->UpdateResourceImmediate(true);
@@ -1617,7 +1629,7 @@ void FTurboSequence_Utility_Lf::UpdateInstanceTransform_Internal(FSkinnedMeshRef
                                                                  const FSkinnedMeshRuntime_Lf& Runtime,
                                                                  const TArray<FCameraView_Lf>& PlayerViews,
                                                                  TMap<TObjectPtr<UTurboSequence_MeshAsset_Lf>,
-																	FRenderingMaterialMap_Lf>& RenderComponents)
+                                                                      FRenderingMaterialMap_Lf>& RenderComponents)
 {
 	FRenderData_Lf& RenderData = Reference.RenderData[Runtime.MaterialsHash];
 
@@ -1639,7 +1651,7 @@ void FTurboSequence_Utility_Lf::UpdateInstanceTransform_Concurrent(FSkinnedMeshR
                                                                    const FTransform& WorldSpaceTransform,
                                                                    const bool bForce,
                                                                    TMap<TObjectPtr<UTurboSequence_MeshAsset_Lf>,
-																	FRenderingMaterialMap_Lf>& RenderComponents)
+                                                                        FRenderingMaterialMap_Lf>& RenderComponents)
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::UpdateInstanceTransform_Concurrent);
 	if (bForce || Runtime.EIsVisibleOverride !=
@@ -1677,7 +1689,7 @@ void FTurboSequence_Utility_Lf::AddRenderInstance(FSkinnedMeshReference_Lf& Refe
                                                   const FSkinnedMeshRuntime_Lf& Runtime,
                                                   FCriticalSection& CriticalSection,
                                                   TMap<TObjectPtr<UTurboSequence_MeshAsset_Lf>,
-													FRenderingMaterialMap_Lf>& RenderComponents,
+                                                       FRenderingMaterialMap_Lf>& RenderComponents,
                                                   const FTransform& WorldSpaceTransform)
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::AddRenderInstance);
@@ -1705,13 +1717,14 @@ void FTurboSequence_Utility_Lf::AddRenderInstance(FSkinnedMeshReference_Lf& Refe
 
 	//RenderData.IncrementUniqueID(); // Use the same ID as Niagara
 	//RenderData.ParticlesToRemove.Add(false);
-	
+
 	if (IsValid(RenderComponents[Runtime.DataAsset].Renderer[Runtime.MaterialsHash].IsmRenderer))
 	{
 		TArray<float> CustomData;
 		CustomData.SetNum(FTurboSequence_Helper_Lf::NumInstanceCustomData);
 		RenderData.ParticleCustomDataIsm.Add(CustomData);
-		RenderComponents[Runtime.DataAsset].Renderer[Runtime.MaterialsHash].IsmRenderer->AddInstance(WorldSpaceTransform, true);
+		RenderComponents[Runtime.DataAsset].Renderer[Runtime.MaterialsHash].IsmRenderer->AddInstance(
+			WorldSpaceTransform, true);
 	}
 
 
@@ -1743,17 +1756,17 @@ void FTurboSequence_Utility_Lf::RemoveRenderInstance(FSkinnedMeshReference_Lf& R
                                                      FCriticalSection& CriticalSection,
                                                      FSkinnedMeshGlobalLibrary_Lf& Library,
                                                      TMap<TObjectPtr<UTurboSequence_MeshAsset_Lf>,
-														FRenderingMaterialMap_Lf>& RenderComponents)
+                                                          FRenderingMaterialMap_Lf>& RenderComponents)
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::RemoveRenderInstance);
 	FScopeLock Lock(&CriticalSection);
 
 	FRenderData_Lf& RenderData = Reference.RenderData[Runtime.MaterialsHash];
-	
+
 	Library.BlackListedMeshIDs.Add(Runtime.GetMeshID(), false);
 
 	const int32 InstanceIndex = RenderData.InstanceMap[Runtime.GetMeshID()];
-	
+
 	if (IsValid(RenderComponents[Runtime.DataAsset].Renderer[Runtime.MaterialsHash].IsmRenderer))
 	{
 		RenderComponents[Runtime.DataAsset].Renderer[Runtime.MaterialsHash].IsmRenderer->RemoveInstance(InstanceIndex);
@@ -2495,7 +2508,8 @@ void FTurboSequence_Utility_Lf::AddAnimation(FSkinnedMeshRuntime_Lf& Runtime, co
 		{
 			Runtime.AnimationGroups[Animation.AnimationGroupLayerHash].NumAnimationsInGroup++;
 		}
-		Runtime.AnimationMetaData.Add(Animation);
+		int32 MetaDataIdx = Runtime.AnimationMetaData.Add(Animation);
+		Runtime.AnimSeqToMetaData.Add(Animation.Animation, MetaDataIdx);
 		Runtime.AnimationMetaData_RenderThread.Add(Animation_RenderThread);
 		Runtime.AnimationIDs.Add(Animation.AnimationID, GET0_NUMBER);
 
@@ -2565,6 +2579,14 @@ void FTurboSequence_Utility_Lf::RemoveAnimation(FSkinnedMeshRuntime_Lf& Runtime,
 		if (Runtime.AnimationIDs.Contains(AnimationID))
 		{
 			Runtime.AnimationIDs.Remove(AnimationID);
+		}
+		Runtime.AnimSeqToMetaData.Remove(Animation.Animation);
+		for (auto& [AnimSeq, Idx] : Runtime.AnimSeqToMetaData)
+		{
+			if (Idx > Index)
+			{
+				Idx--;
+			}
 		}
 		Runtime.AnimationMetaData.RemoveAt(Index);
 		Runtime.AnimationMetaData_RenderThread.RemoveAt(Index);
@@ -3330,11 +3352,11 @@ void FTurboSequence_Utility_Lf::ExtractRootMotionFromAnimations(FTransform& OutA
 				ETurboSequence_RootMotionMode_Lf::Force || (Mode ==
 					ETurboSequence_RootMotionMode_Lf::OnRootBoneAnimated && Animation.bIsRootBoneAnimation)))
 		{
-		        FAnimExtractContext AnimExtract = FAnimExtractContext ( (double)Animation.AnimationTime,
-                                                                                true,
-                                                                                FDeltaTimeRecord(DeltaTime),
-                                                                                Animation.bIsLoop );
-                                              
+			FAnimExtractContext AnimExtract = FAnimExtractContext(static_cast<double>(Animation.AnimationTime),
+			                                                      true,
+			                                                      FDeltaTimeRecord(DeltaTime),
+			                                                      Animation.bIsLoop);
+
 			FTransform RootMotion_Transform = Animation.Animation->ExtractRootMotion(AnimExtract);
 
 			float Scalar = Animation.FinalAnimationWeight * Animation.Settings.AnimationSpeed;

--- a/Source/TurboSequence_Lf/Public/TurboSequence_Data_Lf.h
+++ b/Source/TurboSequence_Lf/Public/TurboSequence_Data_Lf.h
@@ -55,7 +55,8 @@ struct TURBOSEQUENCE_LF_API FRenderData_Lf
 {
 	GENERATED_BODY()
 
-	explicit FRenderData_Lf(const FString& EmitterName, const FString& ParticleIDName, const FString& PositionName, const FString& RotationName,
+	explicit FRenderData_Lf(const FString& EmitterName, const FString& ParticleIDName, const FString& PositionName,
+	                        const FString& RotationName,
 	                        const FString& ScaleName, const FString& MeshName, const FString& MaterialsName,
 	                        const FString& LodName, const FString& CustomDataName, const FString& ParticleRemoveName,
 	                        const FString& UseNaniteName)
@@ -120,7 +121,6 @@ struct TURBOSEQUENCE_LF_API FRenderData_Lf
 	bool bChangedScaleCollectionThisFrame = false;
 	bool bChangedLodCollectionThisFrame = false;
 	bool bChangedCustomDataCollectionThisFrame = false;
-
 
 private:
 	FString EmitterName;
@@ -197,6 +197,7 @@ public:
 	{
 		return ParticleRemoveName;
 	}
+
 	FORCEINLINE FString& GetUseNaniteName()
 	{
 		return UseNaniteName;
@@ -410,7 +411,7 @@ struct TURBOSEQUENCE_LF_API FRenderingMaterialItem_Lf
 
 	UPROPERTY(VisibleAnywhere, Category="TurboSequence")
 	TObjectPtr<UNiagaraComponent> NiagaraRenderer;
-	
+
 	UPROPERTY(VisibleAnywhere, Category="TurboSequence")
 	TObjectPtr<UInstancedStaticMeshComponent> IsmRenderer;
 
@@ -625,7 +626,8 @@ struct TURBOSEQUENCE_LF_API FSkinnedMeshRuntime_Lf : public FSkinnedMeshRuntime_
 	                                const TObjectPtr<UTurboSequence_MeshAsset_Lf> Asset,
 	                                const int32 OverrideMeshID = INDEX_NONE)
 	{
-		if (OverrideMeshID > INDEX_NONE && !InputCollection.Contains(OverrideMeshID) && !BlacklistedMeshIDs.Contains(OverrideMeshID))
+		if (OverrideMeshID > INDEX_NONE && !InputCollection.Contains(OverrideMeshID) && !BlacklistedMeshIDs.Contains(
+			OverrideMeshID))
 		{
 			MeshID = OverrideMeshID;
 		}
@@ -633,7 +635,8 @@ struct TURBOSEQUENCE_LF_API FSkinnedMeshRuntime_Lf : public FSkinnedMeshRuntime_
 		{
 			MeshID = FMath::RandRange(0, INT32_MAX - 1);
 			MeshID++;
-			while ((InputCollection.Contains(MeshID) || BlacklistedMeshIDs.Contains(MeshID)) || ((!InputCollection.Contains(MeshID) && !BlacklistedMeshIDs.Contains(MeshID)) && MeshID < GET0_NUMBER))
+			while ((InputCollection.Contains(MeshID) || BlacklistedMeshIDs.Contains(MeshID)) || ((!InputCollection.
+				Contains(MeshID) && !BlacklistedMeshIDs.Contains(MeshID)) && MeshID < GET0_NUMBER))
 			{
 				MeshID = FMath::RandRange(0, INT32_MAX - 1);
 				MeshID++;
@@ -664,6 +667,7 @@ struct TURBOSEQUENCE_LF_API FSkinnedMeshRuntime_Lf : public FSkinnedMeshRuntime_
 	FTransform WorldSpaceTransform = FTransform::Identity;
 
 	TArray<FAnimationMetaData_Lf> AnimationMetaData;
+	TMap<TObjectPtr<UAnimSequence>, int32> AnimSeqToMetaData;
 	// < Animation ID | Animation Index >
 	TMap<uint32, int32> AnimationIDs;
 

--- a/Source/TurboSequence_Lf/Public/TurboSequence_Manager_Lf.h
+++ b/Source/TurboSequence_Lf/Public/TurboSequence_Manager_Lf.h
@@ -142,7 +142,7 @@ protected:
 		                                               TArray<TObjectPtr<UMaterialInterface>>(),
 	                                               const TObjectPtr<UTurboSequence_FootprintAsset_Lf>& FootprintAsset =
 		                                               nullptr,
-		                                               const int32 OverrideMeshID = INDEX_NONE);
+	                                               const int32 OverrideMeshID = INDEX_NONE);
 
 	static bool RemoveSkinnedMeshInstance_GameThread(int32 MeshID, const TObjectPtr<UWorld> InWorld);
 
@@ -430,6 +430,20 @@ public:
 	                                                                        AnimSettings
 	);
 
+	/**
+	 * Set the AnimationTime of an animation in a Mesh's AnimationMetaData, 
+	 * so you can control the time by yourself.
+	 * 
+	 * The AnimSettings.bAnimationTimeSelfManaged should be
+	 * set to true when initially starting the animation with PlayAnimation_Concurrent.
+	 * 
+	 * @param MeshData The Mesh ID
+	 * @param AnimSequence The Animation which is self managed
+	 * @param NewTime The new Time in seconds to set in the Animation
+	 */
+	UFUNCTION(BlueprintCallable, Category="Turbo Sequence")
+	static void SetSelfManagedAnimSequenceTime(
+		const FTurboSequence_MinimalMeshData_Lf& MeshData, UAnimSequence* AnimSequence, float NewTime);
 
 	/**
 	 * Playing an Blend Space
@@ -457,10 +471,10 @@ public:
 
 
 	// /**
- // * Gets all Animations Playing right now on the character as an animation collection array
- // * @param OutAnimations The animation collection array output
- // * @param MeshData The Mesh ID
- // */
+	// * Gets all Animations Playing right now on the character as an animation collection array
+	// * @param OutAnimations The animation collection array output
+	// * @param MeshData The Mesh ID
+	// */
 	// UFUNCTION(BlueprintPure, Category="Turbo Sequence",
 	// 	meta=(ReturnDisplayName="Animation Sequence", Keywords="Turbo, Sequence, TS, Get, Animation, Play, Priority"))
 	// static void GetAllAnimationsFromMeshData_Concurrent(
@@ -687,8 +701,8 @@ public:
 	UFUNCTION(BlueprintCallable, Category="Turbo Sequence",
 		meta=(ReturnDisplayName="Success", Keywords="Turbo, Sequence, TS, Set, Customize, Change, Mesh, Material"))
 	static int32 CustomizeMesh_RawID_GameThread(int32 MeshID,
-	                                           UTurboSequence_MeshAsset_Lf* TargetMesh,
-	                                           const TArray<UMaterialInterface*>& TargetMaterials);
+	                                            UTurboSequence_MeshAsset_Lf* TargetMesh,
+	                                            const TArray<UMaterialInterface*>& TargetMaterials);
 
 	/**
 	 * Customizes the Mesh with a Target Spawn data
@@ -767,6 +781,15 @@ public:
 	static bool SetCustomDataToInstance_Concurrent(const FTurboSequence_MinimalMeshData_Lf& MeshData,
 	                                               const uint8 CustomDataFractionIndex, const float CustomDataValue);
 
+	/**
+	 * Looks up the MetaData of the given AnimSeq for the given MeshID.
+	 * @param MeshID The Mesh ID
+	 * @param AnimSeq The Animation Sequence which is playing on the Mesh
+	 * @param OutMetaData The Output MetaData
+	 * @return True if Successful
+	 */
+	static bool GetMetaDataForAnimSeq(
+		int32 MeshID, UAnimSequence* AnimSeq, FAnimationMetaData_Lf& OutMetaData);
 
 	/**
 	 * Sets the Turbo Sequence Mesh to an equallent UE Mesh using the Ts IK system, make sure the UE Mesh has the same skeleton


### PR DESCRIPTION
This commit adds an AnimSeqToMetaData map on the SkinnedMeshRuntime struct and a function for retrieving AnimMetaData by an AnimSeq: GetMetaDataForAnimSeq. Another function is added, SetSelfManagedAnimSequenceTime, which can be used to set AnimationTime on the metadata

Here is an example of how this can be used:

```cpp
void UEntityIsmProcessor::PlayTSAnimFrame(
	const FTSMeshData& TSMeshData, UAnimSequence* AnimSeq,
	float ElapsedTime, FTurboSequence_AnimPlaySettings_Lf& AnimSettings)
{
	FAnimationMetaData_Lf OutMetaData;
	bool bHasAnimAlreadyPlaying = ATurboSequence_Manager_Lf::GetMetaDataForAnimSeq(
		TSMeshData.TSMeshData.RootMotionMeshID, AnimSeq, OutMetaData);

	AnimSettings.AnimationPlayTimeInSeconds = ElapsedTime;
	if (!bHasAnimAlreadyPlaying)
	{
		AnimSettings.bAnimationTimeSelfManaged = true;
		FTurboSequence_AnimMinimalCollection_Lf AnimCollection =
			ATurboSequence_Manager_Lf::PlayAnimation_Concurrent(
				TSMeshData.TSMeshData, AnimSeq, AnimSettings);
	}
	ATurboSequence_Manager_Lf::SetSelfManagedAnimSequenceTime(
		TSMeshData.TSMeshData, AnimSeq, AnimSettings.AnimationPlayTimeInSeconds);
}
```