### PR TITLE
Change TS RuntimeSkinnedMeshesHashMap removal to RemoveAtSwap

### DIFF
--- a/Source/TurboSequence_Lf/Private/TurboSequence_Manager_Lf.cpp
+++ b/Source/TurboSequence_Lf/Private/TurboSequence_Manager_Lf.cpp
@@ -629,36 +629,34 @@ bool ATurboSequence_Manager_Lf::RemoveSkinnedMeshInstance_GameThread(int32 MeshI
 	{
 		FTurboSequence_Utility_Lf::CleanVisualRenderer(Instance->RenderComponents, Reference, Runtime);
 	}
+	
+	const int32 GlobalIndex = GlobalLibrary.MeshIDToGlobalIndex[Runtime.GetMeshID()];
 	GlobalLibrary.RuntimeSkinnedMeshes.Remove(Runtime.GetMeshID());
-	GlobalLibrary.RuntimeSkinnedMeshesHashMap.Remove(Runtime.GetMeshID());
+
+	int32 SwappedMeshID = GlobalLibrary.RuntimeSkinnedMeshesHashMap.Last();
+	GlobalLibrary.RuntimeSkinnedMeshesHashMap.RemoveAtSwap(GlobalIndex);
+
+	GlobalLibrary.MeshIDToGlobalIndex.Remove(Runtime.GetMeshID());
 	GlobalLibrary.MeshIDToMinimalData.Remove(Runtime.GetMeshID());
 
-	const int32 GlobalIndex = GlobalLibrary.MeshIDToGlobalIndex[Runtime.GetMeshID()];
-	GlobalLibrary.MeshIDToGlobalIndex.Remove(Runtime.GetMeshID());
-	for (TTuple<int32, int32>& Index : GlobalLibrary.MeshIDToGlobalIndex)
-	{
-		if (Index.Value > GlobalIndex)
-		{
-			Index.Value--;
-		}
-	}
+	// No update needed if we are removing the last one
+	if (SwappedMeshID != Runtime.GetMeshID())
+		GlobalLibrary.MeshIDToGlobalIndex[SwappedMeshID] = GlobalIndex;
 
 	const int32 MeshID_RenderThread = Runtime.GetMeshID();
 	ENQUEUE_RENDER_COMMAND(TurboSequence_RemoveRenderInstance_Lf)(
 		[&Library_RenderThread, MeshID_RenderThread](FRHICommandListImmediate& RHICmdList)
 		{
 			const int32 GlobalIndex = Library_RenderThread.MeshIDToGlobalIndex[MeshID_RenderThread];
-			Library_RenderThread.MeshIDToGlobalIndex.Remove(MeshID_RenderThread);
-			for (TTuple<int32, int32>& Index : Library_RenderThread.MeshIDToGlobalIndex)
-			{
-				if (Index.Value > GlobalIndex)
-				{
-					Index.Value--;
-				}
-			}
 
 			Library_RenderThread.RuntimeSkinnedMeshes.Remove(MeshID_RenderThread);
-			Library_RenderThread.RuntimeSkinnedMeshesHashMap.Remove(MeshID_RenderThread);
+			int32 SwappedMeshID = Library_RenderThread.RuntimeSkinnedMeshesHashMap.Last();
+			Library_RenderThread.RuntimeSkinnedMeshesHashMap.RemoveAtSwap(GlobalIndex);
+
+			Library_RenderThread.MeshIDToGlobalIndex.Remove(MeshID_RenderThread);
+			// No update needed if we are removing the last one
+			if (SwappedMeshID != MeshID_RenderThread)
+				Library_RenderThread.MeshIDToGlobalIndex[SwappedMeshID] = GlobalIndex;
 		});
 
 

--- a/Source/TurboSequence_Lf/Private/TurboSequence_Utility_Lf.cpp
+++ b/Source/TurboSequence_Lf/Private/TurboSequence_Utility_Lf.cpp
@@ -1882,6 +1882,11 @@ void FTurboSequence_Utility_Lf::UpdateCullingAndLevelOfDetail(FSkinnedMeshRuntim
                                                               FSkinnedMeshGlobalLibrary_Lf& Library)
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(FTurboSequence_Utility_Lf::UpdateCullingAndLevelOfDetail);
+	if (Reference.DataAsset->bUseNanite)
+	{
+		Runtime.LodIndex = GET0_NUMBER;
+		return;
+	}
 	float ClosestCameraDistance = GET_INFINITY;
 	const FVector& ComponentLocation = Runtime.WorldSpaceTransform.GetLocation();
 	for (const FCameraView_Lf& CameraView : CameraViews)


### PR DESCRIPTION
Change to `.RemoveAtSwap` as this is a much more performant O(1) removal for an array rather than doing a O(n) `.Remove` by value. This also more performant as it prevents the need for iterating over `GlobalLibrary.MeshIDToGlobalIndex` to adjust all of the indices and instead we only need to update the one swapped index.

Niagara also rerenders the particles when they change in the array, `.Remove` would cause most of the array to change which causes a lot of flickering if many are removed. With `.RemoveAtSwap` only one particle changes and flickers. 


This also includes a change to bypass the update LOD logic when the mesh uses nanite. Tested with 1k modular TS meshes, you can see it is >1ms performance improvement.

Before Change:
<img width="1648" height="243" alt="Before change" src="https://github.com/user-attachments/assets/e5e02fcd-49c5-4e2d-a6dd-065f33d65afa" />

After Change:
<img width="1588" height="224" alt="After change" src="https://github.com/user-attachments/assets/b049a490-f08c-4237-9598-3f0dc18b68d6" />
